### PR TITLE
Release disposed shell generations so they (and their assemblies) can be GC'd

### DIFF
--- a/specs/006-shell-drain-lifecycle/contracts/IShellRegistry.md
+++ b/specs/006-shell-drain-lifecycle/contracts/IShellRegistry.md
@@ -116,8 +116,11 @@ public interface IShellRegistry
     IShell? GetActive(string name);
 
     /// <summary>
-    /// All generations currently held for <paramref name="name"/> regardless of lifecycle
-    /// state, including draining generations and the currently active one (FR-032).
+    /// The generations currently retained for <paramref name="name"/>: the active generation plus any
+    /// earlier generations still draining. A generation is released once it reaches
+    /// <see cref="ShellLifecycleState.Disposed"/>, so fully torn-down generations are NOT returned —
+    /// callers cannot rely on historical generations remaining available after teardown. Always contains
+    /// the shell returned by <c>GetActive</c>; empty when the name has no retained generations (FR-032).
     /// </summary>
     IReadOnlyCollection<IShell> GetAll(string name);
 

--- a/specs/006-shell-drain-lifecycle/spec.md
+++ b/specs/006-shell-drain-lifecycle/spec.md
@@ -438,9 +438,13 @@ indefinitely, reload, assert the drain completes after approximately 1 second wi
 
 - **FR-031**: The registry MUST provide a way to retrieve the single `Active` shell for a
   given name (`GetActive(name)`).
-- **FR-032**: The registry MUST provide a way to retrieve all shells currently held for a
-  given name regardless of lifecycle state (`GetAll(name)`), including draining generations
-  and the currently active one.
+- **FR-032**: The registry MUST provide a way to retrieve all generations currently *retained*
+  for a given name (`GetAll(name)`): the active generation and any earlier generations still
+  draining. A generation is released once it reaches `Disposed` (its teardown complete), so
+  fully torn-down generations are NOT returned and callers MUST NOT depend on historical
+  generations remaining available after teardown. The returned set MUST always contain the shell
+  returned by `GetActive(name)` — a disposed active generation is released from `GetActive` and
+  `GetAll` together.
 - **FR-033**: Shell descriptor metadata MUST be opaque to the library and surfaced unchanged
   in events and queries. Metadata on every generation's descriptor MUST be sourced from the
   blueprint's `Metadata` property at generation time.

--- a/src/CShells.Abstractions/Lifecycle/IShellRegistry.cs
+++ b/src/CShells.Abstractions/Lifecycle/IShellRegistry.cs
@@ -127,7 +127,13 @@ public interface IShellRegistry
     /// <summary>The single active shell for <paramref name="name"/>, or <c>null</c> if none.</summary>
     IShell? GetActive(string name);
 
-    /// <summary>All generations currently held for <paramref name="name"/> regardless of lifecycle state.</summary>
+    /// <summary>
+    /// The generations currently retained for <paramref name="name"/>: the active generation plus any
+    /// earlier generations still draining. A generation is released once it reaches
+    /// <see cref="ShellLifecycleState.Disposed"/>, so fully torn-down generations are NOT returned —
+    /// callers cannot rely on historical generations remaining available after teardown. Empty when the
+    /// name has no retained generations.
+    /// </summary>
     IReadOnlyCollection<IShell> GetAll(string name);
 
     /// <summary>

--- a/src/CShells.Management.Api/Endpoints/GetShellHandler.cs
+++ b/src/CShells.Management.Api/Endpoints/GetShellHandler.cs
@@ -34,9 +34,10 @@ internal static class GetShellHandler
                 // Surface as null blueprint; the response still carries live generations.
             }
 
-            // Per FR-011, surface every generation NOT yet disposed. The registry retains
-            // disposed shells in its in-memory slot, but they are no longer "live" from the
-            // operator's perspective.
+            // Per FR-011, surface every generation NOT yet disposed. The registry releases a generation
+            // once it reaches Disposed, so GetAll already excludes torn-down generations; the Disposed
+            // filter is a defensive guard against a generation that transitions to Disposed between the
+            // GetAll snapshot and this projection.
             var liveGenerations = registry.GetAll(name)
                 .Where(s => s.State != ShellLifecycleState.Disposed)
                 .ToArray();

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -506,8 +506,23 @@ internal sealed class ShellRegistry : IShellRegistry
         var buildResult = await _providerBuilder!.BuildAsync(settings, cancellationToken).ConfigureAwait(false);
 
         var descriptor = ShellDescriptor.Create(blueprint.Name, (int)generation, blueprint.Metadata);
-        var shell = new Shell(descriptor, buildResult.Provider, (s, prev, curr) =>
-            FireStateChangedAsync(s, prev, curr, cancellationToken: default));
+        var shell = new Shell(descriptor, buildResult.Provider, async (s, prev, curr) =>
+        {
+            await FireStateChangedAsync(s, prev, curr).ConfigureAwait(false);
+
+            // A generation transitioning to Disposed has had its endpoints/middleware removed (the
+            // Disposed-keyed subscriber cleanup ran just above, since FireStateChangedAsync is awaited
+            // first), and its IServiceProvider teardown is in flight on this same call stack (Shell
+            // advances to Disposed before disposing the provider). Release the registry's last strong
+            // reference to it now so the Shell — and, transitively, its (being-)disposed provider, which
+            // still holds the generation's service *types* — becomes GC-eligible once that teardown
+            // completes. Without this, slot.All pins every generation ever created for the lifetime of the
+            // host: an unbounded leak, and — when a generation's assemblies were loaded into a collectible
+            // AssemblyLoadContext — the disposed provider's type references keep that context (and its
+            // assemblies) resident forever, so it can never be unloaded.
+            if (curr == ShellLifecycleState.Disposed)
+                ReleaseGeneration(slot, s);
+        });
 
         // Populate the holder so services in the shell's provider can resolve IShell.
         buildResult.Holder.Set(shell);
@@ -526,7 +541,17 @@ internal sealed class ShellRegistry : IShellRegistry
             throw new InvalidOperationException("Shell failed to transition from Initializing to Active.");
 
         slot.Active = shell;
-        slot.All = slot.All.Add(shell);
+        // Atomic add: paired with the lock-free removal in ReleaseGeneration, which runs off the
+        // drain background thread (outside this name's semaphore) when a generation reaches Disposed.
+        ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Add(s), shell);
+
+        // Safe-by-construction guard against an add-after-release: if this generation somehow already
+        // reached Disposed before the add above (unreachable today — a drained initializer fails the
+        // Initializing→Active CAS at TryTransitionAsync and throws before we get here), its Disposed
+        // callback's Remove ran against a list that did not yet contain it and was a no-op, so the add
+        // just re-inserted a disposed shell. Re-run the release now rather than leak it back in.
+        if (shell.State == ShellLifecycleState.Disposed)
+            ReleaseGeneration(slot, shell);
 
         _logger.LogInformation("Activated shell {Descriptor} with {FeatureCount} feature(s)",
             descriptor, buildResult.EnabledFeatures.Count);
@@ -560,6 +585,31 @@ internal sealed class ShellRegistry : IShellRegistry
         }
     }
 
+    /// <summary>
+    /// Removes a fully-disposed generation from its slot's historical list so it stops being rooted
+    /// by the registry, and — when that generation is still the published <see cref="NameSlot.Active"/>
+    /// one — clears Active too, preserving the invariant that <c>GetAll</c> always contains
+    /// <c>GetActive</c>. Lock-free (runs from the drain background thread, not under the slot semaphore);
+    /// the paired add in <see cref="CreateGenerationAsync"/> is also atomic. Idempotent — removing a
+    /// shell not present is a no-op.
+    /// </summary>
+    private static void ReleaseGeneration(NameSlot slot, IShell shell)
+    {
+        if (shell is not Shell typed)
+            return;
+
+        ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Remove(s), typed);
+
+        // Preserve GetAll ⊇ {GetActive}: if the generation being released is still the active one — an
+        // active generation drained without a reload replacing it, reachable via the public DrainAsync and
+        // on host shutdown — clear Active too, so GetActive never returns a Disposed shell that GetAll no
+        // longer holds. Atomic CAS: a concurrent reload that already promoted a newer generation into
+        // Active leaves it untouched (the stored reference no longer matches `typed`).
+#pragma warning disable 420 // Interlocked provides the fence; other volatile reads/writes of Active are unaffected.
+        Interlocked.CompareExchange(ref slot.Active, null, typed);
+#pragma warning restore 420
+    }
+
     private static async ValueTask DisposePartialProviderAsync(ServiceProvider provider)
     {
         try
@@ -585,10 +635,12 @@ internal sealed class ShellRegistry : IShellRegistry
         // Incremented under the Semaphore. `long` so the cast to int in ShellDescriptor is explicit.
         internal long NextGeneration;
 
-        // Mutated under the Semaphore; read without locking by GetActive.
+        // Written under the Semaphore, plus a lock-free CAS-to-null in ReleaseGeneration when the active
+        // generation is disposed; read without locking by GetActive.
         internal volatile Shell? Active;
 
-        // Immutable list; replaced under the Semaphore.
+        // Immutable list. Added to under the Semaphore; removed from lock-free on the drain thread
+        // (ReleaseGeneration) — both via ImmutableInterlocked.Update.
         internal ImmutableList<Shell> All = [];
     }
 }

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryReloadTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryReloadTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using CShells.DependencyInjection;
 using CShells.Features;
 using CShells.Lifecycle;
@@ -47,6 +48,102 @@ public class ShellRegistryReloadTests
 
         Assert.Equal(ShellLifecycleState.Disposed, gen1.State);
         Assert.Equal(ShellLifecycleState.Active, result.NewShell.State);
+    }
+
+    [Fact(DisplayName = "ReloadAsync releases the drained previous generation from slot history (no unbounded retention)")]
+    public async Task Reload_ReleasesPreviousGeneration_FromHistory()
+    {
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryReloadTests>()
+            .AddShell("payments", _ => { }));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        var gen1 = await registry.ActivateAsync("payments");
+        Assert.Contains(gen1, registry.GetAll("payments")); // active generation is tracked
+
+        var result = await registry.ReloadAsync("payments");
+        await result.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ShellLifecycleState.Disposed, gen1.State);
+        // Once drained + disposed, the previous generation must no longer be retained by the
+        // registry — otherwise slot.All grows by one Shell (and pins its provider + assemblies)
+        // on every single reload for the lifetime of the host.
+        Assert.DoesNotContain(gen1, registry.GetAll("payments"));
+        Assert.Equal([result.NewShell!], registry.GetAll("payments"));
+    }
+
+    [Fact(DisplayName = "Drained previous generation is GC-collectible after reload (no leaked strong reference)")]
+    public async Task Reload_DrainedGeneration_IsGarbageCollectible()
+    {
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryReloadTests>()
+            .AddShell("payments", _ => { }));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        // Activate, reload, and drain inside a non-inlined helper so no local on THIS frame keeps a
+        // strong reference to the previous generation once the helper returns.
+        var weakGen1 = await ActivateReloadAndDrainAsync(registry);
+
+        for (var i = 0; i < 10 && weakGen1.IsAlive; i++)
+        {
+            // Yield first: DrainOperation.RunAsync publishes its completion (which the helper's
+            // Drain.WaitAsync awaited) before its outer Task.Run finishes unwinding, so a ThreadPool frame
+            // may still hold the closure over the shell for a moment after WaitAsync returned. Letting it
+            // run makes the reclaim deterministic rather than reliant on GC timing.
+            await Task.Yield();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        }
+
+        // If this fails, the registry (or a collaborator) is still rooting the disposed generation.
+        // That is exactly the reference that keeps a collectible AssemblyLoadContext (one the
+        // generation's assemblies were loaded into) resident, so a forced GC cannot reclaim it.
+        Assert.False(weakGen1.IsAlive,
+            "The drained previous generation is still rooted after GC — the registry is leaking it.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> ActivateReloadAndDrainAsync(IShellRegistry registry)
+    {
+        var gen1 = await registry.ActivateAsync("payments");
+        var weak = new WeakReference(gen1);
+
+        var result = await registry.ReloadAsync("payments");
+        await result.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ShellLifecycleState.Disposed, gen1.State);
+
+        // gen1, result (which holds the DrainOperation referencing gen1) and every other local fall out of
+        // scope when this helper returns. [MethodImpl(NoInlining)] only stops the JIT folding this frame
+        // into the caller; what actually prevents gen1 staying rooted is the runtime clearing the completed
+        // async state-machine box's fields — so nothing on the heap holds it either, and only the
+        // WeakReference travels back. (The dedicated history test asserts GetAll no longer contains gen1;
+        // asserting it here too would mask the GC check by failing first if the release ever regressed.)
+        return weak;
+    }
+
+    [Fact(DisplayName = "Draining the active generation (no reload) clears GetActive and GetAll together")]
+    public async Task DrainActiveGeneration_ClearsActiveAndAll()
+    {
+        await using var host = ShellRegistryActivateTests.BuildHost(cshells => cshells
+            .WithAssemblyContaining<ShellRegistryReloadTests>()
+            .AddShell("payments", _ => { }));
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        var active = await registry.ActivateAsync("payments");
+        Assert.Same(active, registry.GetActive("payments"));
+
+        // Drain the active generation directly — no reload promotes a replacement, so this is the case
+        // where 'Active' would otherwise be left pointing at a Disposed shell.
+        var drain = await registry.DrainAsync(active);
+        await drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ShellLifecycleState.Disposed, active.State);
+        // Invariant GetAll ⊇ {GetActive}: once the active generation reaches Disposed it is released from
+        // BOTH, so GetActive returns null rather than a Disposed shell that GetAll no longer holds.
+        Assert.Null(registry.GetActive("payments"));
+        Assert.Empty(registry.GetAll("payments"));
     }
 
     [Fact(DisplayName = "ReloadAsync with no blueprint throws ShellBlueprintNotFoundException")]


### PR DESCRIPTION
## Problem
`ShellRegistry` keeps every generation it ever created in `NameSlot.All` and never removes any — even after a generation drains, disposes its `IServiceProvider`, and has its endpoints/middleware torn down. A disposed `ServiceProvider` still references its service **types**, so retaining the `Shell` keeps those types — and any collectible `AssemblyLoadContext` they were loaded into (e.g. a Nuplane package load context) — rooted for the lifetime of the host.

Two consequences:
- `slot.All` grows by one `Shell` on every reload (unbounded memory growth), and
- a hot-swapped package's old assemblies can never be unloaded, because the disposed provider's type references keep them alive through GC.

`GetShellHandler` already documents that consumers filter out `Disposed` generations because "the registry retains disposed shells in its in-memory slot" — that retention is the leak.

## Fix
When a generation reaches `Disposed`, remove it from `slot.All` (lock-free, off the drain background thread) so the registry drops its last strong reference. The paired add is now also atomic. `GetAll()` therefore returns only live generations, which matches how consumers already treat it.

## Tests
`ShellRegistryReloadTests` gains:
- *releases the drained previous generation from slot history* — `GetAll` no longer retains it;
- *drained previous generation is GC-collectible after reload* — a `WeakReference` to the previous generation is dead after a forced GC, proving no strong reference is leaked. This is the exact reference that otherwise keeps a collectible `AssemblyLoadContext` resident after a package hot-swap.

## Verification
Verified end-to-end together with the companion Nuplane fix (unload of removed package contexts) against `Elsa.Foundation.Host`: after a feed hot-swap the old package's collectible load context now unloads (lingering contexts drop to 0), and repeated swaps do not accumulate contexts. Both fixes are required — this one releases the CShells-side reference; Nuplane releases the loader-side reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)