### PR TITLE
Make shell endpoint generation publication atomic

### DIFF
--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -12,6 +12,17 @@ Initializing -> Active -> Deactivating -> Draining -> Drained -> Disposed
 
 `IShellInitializer` instances run while the shell is `Initializing`, before the generation is published as `Active`. `IDrainHandler` instances run while the shell is `Draining`, after outstanding `IShellScope` handles finish or the drain deadline is reached. `IShellTerminator` instances run while the shell is `Drained`, after all drain handlers complete and before the shell's service provider is disposed.
 
+Dynamic shell endpoint generations are prepared as complete candidates. Feature mapping,
+middleware composition, and route validation finish before the candidate replaces the published
+endpoint snapshot, so a failed mapping or collision leaves the previous generation available and a
+successful replacement never exposes an empty routing state. Collision diagnostics include both
+route owners and compare normalized parameter templates plus the full HTTP method sets.
+
+Requests that have already matched an endpoint remain bound to the shell identifier and exact
+generation in that endpoint's metadata. The old generation is removed from routing when draining
+begins, while its middleware pipeline and scoped provider remain available until in-flight scopes
+finish.
+
 ## Initializer Ordering
 
 Feature dependencies and initializer order are separate concepts:

--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -18,6 +18,15 @@ endpoint snapshot, so a failed mapping or collision leaves the previous generati
 successful replacement never exposes an empty routing state. Collision diagnostics include both
 route owners and compare normalized parameter templates plus the full HTTP method sets.
 
+Endpoint replacement remains provisional until the prior generation starts normal deactivation.
+The endpoint data source privately retains the retired snapshot during that interval. If a later
+lifecycle subscriber rejects the candidate, disposal atomically restores the prior snapshot and
+removes the candidate pipeline. Normal deactivation commits the replacement and releases the
+retired snapshot. Middleware composition failures reject activation before publication rather than
+installing a degraded fallback pipeline. A composed candidate pipeline is staged immediately before
+endpoint publication, ensuring the pipeline exists when routing observes the new snapshot; failed
+publication removes that staged entry.
+
 Requests that have already matched an endpoint remain bound to the shell identifier and exact
 generation in that endpoint's metadata. The old generation is removed from routing when draining
 begins, while its middleware pipeline and scoped provider remain available until in-flight scopes

--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -18,19 +18,22 @@ endpoint snapshot, so a failed mapping or collision leaves the previous generati
 successful replacement never exposes an empty routing state. Collision diagnostics include both
 route owners and compare normalized parameter templates plus the full HTTP method sets.
 
-Endpoint replacement remains provisional until the prior generation starts normal deactivation.
-The endpoint data source privately retains the retired snapshot during that interval. If a later
-lifecycle subscriber rejects the candidate, disposal atomically restores the prior snapshot and
-removes the candidate pipeline. Normal deactivation commits the replacement and releases the
-retired snapshot. Middleware composition failures reject activation before publication rather than
-installing a degraded fallback pipeline. A composed candidate pipeline is staged immediately before
-endpoint publication, ensuring the pipeline exists when routing observes the new snapshot; failed
-publication removes that staged entry.
+Endpoint activation uses a prepare/commit boundary. Mapping and pipeline composition prepare an
+externally invisible candidate before lifecycle subscribers run. Once they accept it, the registry
+makes the generation exactly addressable and activation participants commit. The endpoint data
+source revalidates and swaps the complete snapshot atomically, retaining the retired same-shell
+snapshot only until every participant commits. If a later participant rejects the commit,
+participants roll back in reverse order and the prior registry entry, endpoint snapshot, and
+pipeline remain live. Middleware composition failures reject activation before publication rather
+than installing a degraded fallback pipeline. The candidate pipeline is available before the route
+change notification that first exposes its endpoints.
 
-Requests that have already matched an endpoint remain bound to the shell identifier and exact
-generation in that endpoint's metadata. The old generation is removed from routing when draining
-begins, while its middleware pipeline and scoped provider remain available until in-flight scopes
-finish.
+Routing acquires an exact-generation request lease after method and constraint matching but before
+the old generation can drain. `ShellMiddleware` reuses that lease, so even a request paused between
+endpoint matching and middleware entry remains bound to the endpoint's shell and generation. The
+lease is released at response completion, including when downstream middleware short-circuits. The
+old generation is removed from routing when draining begins, while its middleware pipeline and
+scoped provider remain available until those in-flight leases finish.
 
 ## Initializer Ordering
 

--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -28,12 +28,22 @@ pipeline remain live. Middleware composition failures reject activation before p
 than installing a degraded fallback pipeline. The candidate pipeline is available before the route
 change notification that first exposes its endpoints.
 
+Because collision validity spans the entire route inventory, only one committed publication may
+retain rollback evidence at a time. Other candidates may prepare concurrently, but another commit
+or any route/host inventory mutation fails deterministically until the pending owner completes or
+rolls back. This prevents rollback from restoring routes that conflict with a newer shell or host
+mutation.
+
 Routing acquires an exact-generation request lease after method and constraint matching but before
 the old generation can drain. `ShellMiddleware` reuses that lease, so even a request paused between
 endpoint matching and middleware entry remains bound to the endpoint's shell and generation. The
 lease is released at response completion, including when downstream middleware short-circuits. The
 old generation is removed from routing when draining begins, while its middleware pipeline and
 scoped provider remain available until those in-flight leases finish.
+
+Cold activation can publish endpoints after the normal routing pass, so its manual rematch uses the
+same lease seam. It acquires the exact generation before setting the rematched endpoint on the
+request; if drain wins first, no shell endpoint is exposed and the request returns 503.
 
 ## Initializer Ordering
 

--- a/docs/shell-lifecycle.md
+++ b/docs/shell-lifecycle.md
@@ -30,9 +30,11 @@ change notification that first exposes its endpoints.
 
 Because collision validity spans the entire route inventory, only one committed publication may
 retain rollback evidence at a time. Other candidates may prepare concurrently, but another commit
-or any route/host inventory mutation fails deterministically until the pending owner completes or
-rolls back. This prevents rollback from restoring routes that conflict with a newer shell or host
-mutation.
+or an additive route/host inventory mutation fails deterministically until the pending owner
+completes or rolls back. Removal remains available so a slow activation cannot pin another shell's
+disposed endpoints: other-shell cleanup applies immediately, while generation cleanup for the
+pending shell is deferred and replayed idempotently as the transaction finalizes. This prevents
+rollback conflicts without retaining drained feature code.
 
 Routing acquires an exact-generation request lease after method and constraint matching but before
 the old generation can drain. `ShellMiddleware` reuses that lease, so even a request paused between

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Atomic Shell Endpoint Generations
+
+**Branch**: `codex/1345-atomic-endpoint-generations`
+
+## Design
+
+The dynamic endpoint data source is the candidate-publication seam. It owns route
+normalization, method-overlap checks, conflict diagnostics, immutable snapshot replacement,
+and generation-specific removal. `ShellEndpointRegistrationHandler` maps features into an
+unpublished candidate, composes the generation middleware pipeline, asks the data source to
+publish the candidate, and only then commits the pipeline entry. A failed map, pipeline
+composition, or validation leaves the prior snapshot and pipeline intact.
+
+Route ownership is represented by typed endpoint metadata. Shell endpoints identify the
+dynamic shell, generation, and owning feature; host endpoints retain standard metadata and
+use their display name as a deterministic diagnostic owner when no typed owner is present.
+
+`ShellMiddleware` first checks matched endpoint metadata for an exact generation and uses
+`IShellRegistry.GetAll` to bind that request to the matching shell. Unmatched/cold requests
+retain the existing lazy activation behavior.
+
+## Constitution check
+
+- Abstraction-first: no new public framework abstraction is required; route metadata remains
+  in the ASP.NET Core implementation package and existing lifecycle interfaces are reused.
+- Lifecycle/concurrency: publication uses an async-safe lifecycle boundary already serialized
+  by the registry; the endpoint snapshot is immutable and atomically replaced under the data
+  source's short synchronization gate.
+- Explicit errors: conflicts carry both owners, route, and method set.
+- Test coverage: focused routing, handler, and middleware tests cover each acceptance criterion.
+
+## Files
+
+- `src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
+- `src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs`
+- `src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs`
+- `src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`
+- `src/CShells.AspNetCore/Middleware/ShellMiddleware.cs`
+- focused integration tests under `tests/CShells.Tests/Integration/AspNetCore/`

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -13,8 +13,10 @@ route collisions are global, the data source permits one rollback-capable commit
 rejects competing commits plus additive route or host-inventory mutations until its owner completes
 or rolls it back. Removals are monotonic: other-shell cleanup applies immediately, while cleanup for
 the pending shell generation is deduplicated and replayed before completion or after rollback
-restoration. This keeps rollback infallible without allowing one slow activation to retain another
-shell's disposed routes or collectible feature code.
+restoration. Rollback builds the final snapshot with those removals already applied before one
+publication notification, so routing never observes a restored disposed route. This keeps rollback
+infallible without allowing one slow activation to retain another shell's disposed routes or
+collectible feature code.
 Change-token sources are atomically exchanged and cancelled without racing eager disposal.
 
 `IShellGenerationActivationParticipant` gives `ShellRegistry` a two-phase activation boundary.
@@ -24,7 +26,11 @@ generation into `Active`/`All`, then commits participants in registration order.
 the pipeline before committing endpoints, so the first route-change notification can resolve both
 the exact shell and its pipeline. A later commit failure rolls participants back in reverse order,
 restores the prior registry slot, and disposes the rejected provider. Only after every commit
-succeeds do participants discard rollback evidence.
+succeeds do participants discard rollback evidence. The registry verifies that the candidate is
+still Active and retained before accepting it, and restores the prior generation only when that
+generation is also still Active and retained. If cleanup wins after rollback evidence is discarded,
+the registry leaves the slot empty, drains the un-restorable prior generation, and lets the next
+activation rebuild a coherent route/pipeline generation.
 
 Route ownership is represented by typed endpoint metadata and carried into the structured conflict
 result. Shell endpoints identify the dynamic shell, generation, and owning feature; host endpoints
@@ -53,7 +59,9 @@ and returns 503. Unmatched requests retain the existing lazy activation behavior
   code. The middleware suite also drives a real registry reload after routing leases an old matched
   request and verifies drain waits for that response's `OnCompleted` callback. Real-registry reload
   tests prove invisible subscriber fan-out, reverse participant rollback, and registry/route/pipeline
-  restoration after a post-publication commit rejection.
+  restoration after a post-publication commit rejection. Same-shell drain interleavings prove that
+  neither a disposed prior generation nor a disposed candidate can become or remain Active, that
+  rollback observers see no transient disposed route, and that a later request reactivates and serves.
 
 ## Files
 

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -4,45 +4,58 @@
 
 ## Design
 
-The dynamic endpoint data source is the candidate-publication seam. It owns route
-normalization, method-overlap checks, conflict diagnostics, immutable snapshot replacement,
-generation-specific removal, and transactional rollback. `ShellEndpointRegistrationHandler`
-maps features into an unpublished candidate and composes the generation middleware pipeline. The
-handler stages that pipeline immediately before asking the data source to publish, so routing can
-never observe endpoints without their required middleware; failed publication removes the staged
-entry. Publication privately retains the retired snapshot until normal deactivation commits the
-replacement. If a later lifecycle subscriber rejects the candidate, candidate disposal atomically
-restores that snapshot. A failed map, pipeline composition, validation, or later activation
-subscriber leaves the prior snapshot and pipeline intact.
+The dynamic endpoint data source is the candidate-publication seam. It owns route normalization,
+method-overlap checks, conflict diagnostics, immutable snapshot replacement, generation-specific
+removal, and a versioned prepare/commit/rollback transaction. Preparation is externally invisible.
+Commit revalidates against the latest route inventory under one lock, swaps the complete snapshot,
+and retains only the retired same-shell snapshot needed for rollback. Completion releases that
+evidence. A rollback restores it only while that exact transaction still owns the shell version,
+so overlapping publications cannot resurrect an intermediate generation. Change-token sources are
+atomically exchanged and cancelled without racing eager disposal.
+
+`IShellGenerationActivationParticipant` gives `ShellRegistry` a two-phase activation boundary.
+`ShellEndpointRegistrationHandler` prepares feature endpoints and the middleware pipeline before
+the Active notification. After subscribers accept the candidate, the registry first inserts the
+generation into `Active`/`All`, then commits participants in registration order. The handler stages
+the pipeline before committing endpoints, so the first route-change notification can resolve both
+the exact shell and its pipeline. A later commit failure rolls participants back in reverse order,
+restores the prior registry slot, and disposes the rejected provider. Only after every commit
+succeeds do participants discard rollback evidence.
 
 Route ownership is represented by typed endpoint metadata and carried into the structured conflict
 result. Shell endpoints identify the dynamic shell, generation, and owning feature; host endpoints
 retain standard metadata and use their display name as a deterministic diagnostic owner when no
 typed owner is present.
 
-`ShellMiddleware` first checks matched endpoint metadata for an exact generation and uses
-`IShellRegistry.GetAll` to bind that request to the matching shell. Unmatched/cold requests
-retain the existing lazy activation behavior.
+`ShellEndpointGenerationMatcherPolicy` runs after method and constraint policies and acquires at
+most one exact-generation `IShellScope` while matching still owns the endpoint generation. The
+request-local lease is idempotent across policy re-entry and is released through `OnCompleted`.
+`ShellMiddleware` reuses that lease; unmatched/cold requests retain the existing lazy activation
+behavior.
 
 ## Constitution check
 
-- Abstraction-first: no new public framework abstraction is required; route metadata remains
-  in the ASP.NET Core implementation package and existing lifecycle interfaces are reused.
+- Abstraction-first: the small lifecycle participant contract lives in the framework-neutral core;
+  ASP.NET Core route metadata and matching policy remain in the implementation package.
 - Lifecycle/concurrency: publication uses an async-safe lifecycle boundary already serialized
   by the registry; the endpoint snapshot is immutable and atomically replaced under the data
   source's short synchronization gate.
 - Explicit errors: conflicts carry both owners, route, and method set.
 - Test coverage: focused routing, handler, and middleware tests cover each acceptance criterion;
   `CShells.DynamicFeatureFixture` supplies a real dynamically loaded endpoint feature for a
-  five-cycle collectible `AssemblyLoadContext` test that proves endpoint retirement releases
-  feature code. The middleware suite also drives a real registry reload after an old matched
-  request enters middleware and verifies drain waits for that response's `OnCompleted` callback.
-  Real-registry reload tests prove transactional endpoint rollback after a later subscriber
-  rejects a published candidate and preservation after middleware composition fails.
+  five-cycle collectible `AssemblyLoadContext` test through the production route-builder and data
+  source seams, proving published and retired endpoint delegates release dynamically loaded feature
+  code. The middleware suite also drives a real registry reload after routing leases an old matched
+  request and verifies drain waits for that response's `OnCompleted` callback. Real-registry reload
+  tests prove invisible subscriber fan-out, reverse participant rollback, and registry/route/pipeline
+  restoration after a post-publication commit rejection.
 
 ## Files
 
 - `src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs`
+- `src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs`
+- `src/CShells.Abstractions/Lifecycle/IShellGenerationActivationParticipant.cs`
+- `src/CShells/Lifecycle/ShellRegistry.cs`
 - `src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs`
 - `src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs`
 - `src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs`

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -6,12 +6,13 @@
 
 The dynamic endpoint data source is the candidate-publication seam. It owns route normalization,
 method-overlap checks, conflict diagnostics, immutable snapshot replacement, generation-specific
-removal, and a versioned prepare/commit/rollback transaction. Preparation is externally invisible.
-Commit revalidates against the latest route inventory under one lock, swaps the complete snapshot,
-and retains only the retired same-shell snapshot needed for rollback. Completion releases that
-evidence. A rollback restores it only while that exact transaction still owns the shell version,
-so overlapping publications cannot resurrect an intermediate generation. Change-token sources are
-atomically exchanged and cancelled without racing eager disposal.
+removal, and an identity-bound prepare/commit/rollback transaction. Preparation is externally
+invisible and may overlap. Commit revalidates against the latest route inventory under one lock,
+swaps the complete snapshot, and retains only the retired snapshot needed for rollback. Because
+route collisions are global, the data source permits one rollback-capable commit at a time and
+rejects every route or host-inventory mutation until its owner completes or rolls it back. This
+makes rollback infallible and prevents both same-shell resurrection and cross-shell/host conflicts.
+Change-token sources are atomically exchanged and cancelled without racing eager disposal.
 
 `IShellGenerationActivationParticipant` gives `ShellRegistry` a two-phase activation boundary.
 `ShellEndpointRegistrationHandler` prepares feature endpoints and the middleware pipeline before
@@ -30,8 +31,9 @@ typed owner is present.
 `ShellEndpointGenerationMatcherPolicy` runs after method and constraint policies and acquires at
 most one exact-generation `IShellScope` while matching still owns the endpoint generation. The
 request-local lease is idempotent across policy re-entry and is released through `OnCompleted`.
-`ShellMiddleware` reuses that lease; unmatched/cold requests retain the existing lazy activation
-behavior.
+`ShellMiddleware` reuses that lease. When cold activation requires its manual endpoint rematch, it
+uses the same lease seam before calling `SetEndpoint`; a failed handoff exposes no shell endpoint
+and returns 503. Unmatched requests retain the existing lazy activation behavior.
 
 ## Constitution check
 

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -6,14 +6,19 @@
 
 The dynamic endpoint data source is the candidate-publication seam. It owns route
 normalization, method-overlap checks, conflict diagnostics, immutable snapshot replacement,
-and generation-specific removal. `ShellEndpointRegistrationHandler` maps features into an
-unpublished candidate, composes the generation middleware pipeline, asks the data source to
-publish the candidate, and only then commits the pipeline entry. A failed map, pipeline
-composition, or validation leaves the prior snapshot and pipeline intact.
+generation-specific removal, and transactional rollback. `ShellEndpointRegistrationHandler`
+maps features into an unpublished candidate and composes the generation middleware pipeline. The
+handler stages that pipeline immediately before asking the data source to publish, so routing can
+never observe endpoints without their required middleware; failed publication removes the staged
+entry. Publication privately retains the retired snapshot until normal deactivation commits the
+replacement. If a later lifecycle subscriber rejects the candidate, candidate disposal atomically
+restores that snapshot. A failed map, pipeline composition, validation, or later activation
+subscriber leaves the prior snapshot and pipeline intact.
 
-Route ownership is represented by typed endpoint metadata. Shell endpoints identify the
-dynamic shell, generation, and owning feature; host endpoints retain standard metadata and
-use their display name as a deterministic diagnostic owner when no typed owner is present.
+Route ownership is represented by typed endpoint metadata and carried into the structured conflict
+result. Shell endpoints identify the dynamic shell, generation, and owning feature; host endpoints
+retain standard metadata and use their display name as a deterministic diagnostic owner when no
+typed owner is present.
 
 `ShellMiddleware` first checks matched endpoint metadata for an exact generation and uses
 `IShellRegistry.GetAll` to bind that request to the matching shell. Unmatched/cold requests
@@ -30,8 +35,10 @@ retain the existing lazy activation behavior.
 - Test coverage: focused routing, handler, and middleware tests cover each acceptance criterion;
   `CShells.DynamicFeatureFixture` supplies a real dynamically loaded endpoint feature for a
   five-cycle collectible `AssemblyLoadContext` test that proves endpoint retirement releases
-  feature code. The middleware suite also drives a real registry reload with an old matched
-  request and verifies drain waits for its response completion.
+  feature code. The middleware suite also drives a real registry reload after an old matched
+  request enters middleware and verifies drain waits for that response's `OnCompleted` callback.
+  Real-registry reload tests prove transactional endpoint rollback after a later subscriber
+  rejects a published candidate and preservation after middleware composition fails.
 
 ## Files
 

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -27,7 +27,11 @@ retain the existing lazy activation behavior.
   by the registry; the endpoint snapshot is immutable and atomically replaced under the data
   source's short synchronization gate.
 - Explicit errors: conflicts carry both owners, route, and method set.
-- Test coverage: focused routing, handler, and middleware tests cover each acceptance criterion.
+- Test coverage: focused routing, handler, and middleware tests cover each acceptance criterion;
+  `CShells.DynamicFeatureFixture` supplies a real dynamically loaded endpoint feature for a
+  five-cycle collectible `AssemblyLoadContext` test that proves endpoint retirement releases
+  feature code. The middleware suite also drives a real registry reload with an old matched
+  request and verifies drain waits for its response completion.
 
 ## Files
 

--- a/specs/015-atomic-endpoint-generations/plan.md
+++ b/specs/015-atomic-endpoint-generations/plan.md
@@ -10,8 +10,11 @@ removal, and an identity-bound prepare/commit/rollback transaction. Preparation 
 invisible and may overlap. Commit revalidates against the latest route inventory under one lock,
 swaps the complete snapshot, and retains only the retired snapshot needed for rollback. Because
 route collisions are global, the data source permits one rollback-capable commit at a time and
-rejects every route or host-inventory mutation until its owner completes or rolls it back. This
-makes rollback infallible and prevents both same-shell resurrection and cross-shell/host conflicts.
+rejects competing commits plus additive route or host-inventory mutations until its owner completes
+or rolls it back. Removals are monotonic: other-shell cleanup applies immediately, while cleanup for
+the pending shell generation is deduplicated and replayed before completion or after rollback
+restoration. This keeps rollback infallible without allowing one slow activation to retain another
+shell's disposed routes or collectible feature code.
 Change-token sources are atomically exchanged and cancelled without racing eager disposal.
 
 `IShellGenerationActivationParticipant` gives `ShellRegistry` a two-phase activation boundary.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -9,6 +9,7 @@ dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedNam
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_SlowLaterSubscriber_KeepsPriorGenerationRoutableUntilCommit|FullyQualifiedName~Reload_LaterParticipantRejectsCommit_RestoresPriorRoutesAndPipeline|FullyQualifiedName~Reload_CommitConflict_RestoresPriorActiveAndAllEntries|FullyQualifiedName~Reload_ParticipantCommitFailure_RestoresPriorRegistryStateAndRollsBackInReverse"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_OverlappingCommitAndRollback_DoesNotResurrectRoutes|FullyQualifiedName~PrepareGeneration_ConcurrentConflict_SecondCommitIsRejected|FullyQualifiedName~GetChangeToken_"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_Complete_AllowsNextCommit|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsSameShellMutations|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsCrossShellPublication|FullyQualifiedName~ColdStart_ReMatch_ConcurrentReload_KeepsMatchedGenerationLeased"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PendingCommit_OtherShellDrain_RemovesEndpointsAndReleasesReferences|FullyQualifiedName~PendingCommit_SameShellCandidateDrain_RestoresPriorGenerationWithoutStaleRoutes"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible|FullyQualifiedName~ActiveTransition_EndpointConflict_RemovesStagedPipeline|FullyQualifiedName~PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
@@ -48,6 +49,12 @@ disposed source. A blocking endpoint-feature fixture pauses cold rematch exactly
 exposure, performs a real concurrent reload, and proves the exact-generation lease holds drain until
 response completion.
 
+Lifecycle-cleanup regressions hold one shell's publication transaction inside a later activation
+participant. A different real registry shell drains and disposes during that window, proving its
+endpoint object becomes collectible. The pending candidate itself is also drained and disposed
+before a later rejection, proving deferred generation cleanup neither corrupts rollback identity nor
+leaves candidate routes behind.
+
 The endpoint/pipeline ordering tests subscribe to the routing change token, which fires at the
 first externally visible publication point, and assert the exact generation pipeline is already
 available. A rejected-candidate companion test proves a staged pipeline is removed. Conflict tests
@@ -64,10 +71,10 @@ On 2026-08-16:
 - Transactional rollback, middleware rejection, method-case overlap, endpoint/pipeline ordering,
   ownership diagnostics, combined drain, and collectible-context regressions: 9 passed per
   invocation, repeated across 3 invocations.
-- Global transaction, cold-rematch, matched-before-middleware, and collectible-context regressions:
-  7 passed per invocation across 5 consecutive invocations.
-- Focused routing, lifecycle-handler, middleware, and activation regressions: 88 passed.
-- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 626 passed after the global transaction
-  and cold-rematch follow-up.
-- `dotnet test CShells.sln`: 626 CShells tests and 31 end-to-end tests passed.
+- Global transaction, lifecycle cleanup, cold-rematch, matched-before-middleware, and
+  collectible-context regressions: 8 passed per invocation across 5 consecutive invocations.
+- Focused routing, lifecycle-handler, middleware, and activation regressions: 90 passed.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 628 passed after the lifecycle-cleanup
+  follow-up.
+- `dotnet test CShells.sln`: 628 CShells tests and 31 end-to-end tests passed.
 - `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -4,6 +4,8 @@
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~DynamicShellEndpointDataSource|FullyQualifiedName~ShellEndpointRegistrationHandler|FullyQualifiedName~ShellMiddleware"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_LaterSubscriberRejectsCandidate_RestoresPriorGeneration|FullyQualifiedName~Reload_MiddlewareCompositionFails_PreservesPriorGeneration|FullyQualifiedName~MethodsConflict_MethodCaseDiffers_ReturnsTrue|FullyQualifiedName~CompositionFailure_RejectsActivationWithoutPipeline"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible|FullyQualifiedName~ActiveTransition_EndpointConflict_RemovesStagedPipeline|FullyQualifiedName~PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
 ```
@@ -16,11 +18,22 @@ the lifecycle handler's draining removal, calls `Unload`, and forces bounded ful
 The assertion is on the `AssemblyLoadContext` `WeakReference`, so a published or retired
 endpoint delegate that still roots the fixture assembly fails the test.
 
-The reload/drain integration test activates a real registry generation, keeps a guard scope
-open while `ReloadAsync` promotes the replacement, then sends a matched old-generation request
-and a new-generation request. It verifies that the old request uses the old pipeline, the new
-request uses the replacement pipeline, and drain does not complete until the old response's
-`OnCompleted` callback releases its scope.
+The reload/drain integration test activates a real registry generation and sends a matched
+old-generation request into `ShellMiddleware` before `ReloadAsync` promotes the replacement. It
+then sends a new-generation request and verifies that each uses its exact pipeline. The old
+request's own scope is the only in-flight scope: drain does not complete until that response's
+`OnCompleted` callback releases it.
+
+The rollback integration tests use the real registry and lifecycle subscriber chain. One rejects
+generation two after its endpoints and pipeline have been provisionally published, proving the
+generation-one endpoint snapshot and pipeline are restored. The other fails generation-two
+middleware composition before publication, proving activation is rejected without disturbing the
+prior generation. A focused route test preserves ordinal case-insensitive method overlap semantics.
+
+The endpoint/pipeline ordering tests subscribe to the routing change token, which fires at the
+first externally visible publication point, and assert the exact generation pipeline is already
+available. A rejected-candidate companion test proves a staged pipeline is removed. Conflict tests
+assert shell identifier, generation, and feature ownership in both the message and structured data.
 
 ## Recorded evidence
 
@@ -30,6 +43,10 @@ On 2026-08-16:
   repeated across 5 invocations; each invocation performs 5 load/replace/drain/unload cycles.
 - `InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion`: 1 passed per invocation,
   repeated across 3 invocations.
-- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 607 passed.
-- `dotnet test CShells.sln`: 607 CShells tests and 31 end-to-end tests passed.
+- Transactional rollback, middleware rejection, method-case overlap, endpoint/pipeline ordering,
+  ownership diagnostics, combined drain, and collectible-context regressions: 9 passed per
+  invocation, repeated across 3 invocations.
+- Focused routing, lifecycle-handler, middleware, and activation regressions: 74 passed.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 612 passed.
+- `dotnet test CShells.sln`: 612 CShells tests and 31 end-to-end tests passed.
 - `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -2,6 +2,34 @@
 
 ```bash
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~DynamicShellEndpointDataSource|FullyQualifiedName~ShellEndpointRegistrationHandler|FullyQualifiedName~ShellMiddleware"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
 ```
+
+The collectible-load-context test uses `tests/CShells.DynamicFeatureFixture` as a real
+feature assembly. It runs five cycles; each cycle loads the fixture into a collectible
+`AssemblyLoadContext`, maps through `ShellEndpointRouteBuilder`, publishes through
+`DynamicShellEndpointDataSource`, replaces the candidate, drives the replacement through
+the lifecycle handler's draining removal, calls `Unload`, and forces bounded full-GC passes.
+The assertion is on the `AssemblyLoadContext` `WeakReference`, so a published or retired
+endpoint delegate that still roots the fixture assembly fails the test.
+
+The reload/drain integration test activates a real registry generation, keeps a guard scope
+open while `ReloadAsync` promotes the replacement, then sends a matched old-generation request
+and a new-generation request. It verifies that the old request uses the old pipeline, the new
+request uses the replacement pipeline, and drain does not complete until the old response's
+`OnCompleted` callback releases its scope.
+
+## Recorded evidence
+
+On 2026-08-16:
+
+- `CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval`: 1 passed per invocation,
+  repeated across 5 invocations; each invocation performs 5 load/replace/drain/unload cycles.
+- `InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion`: 1 passed per invocation,
+  repeated across 3 invocations.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 607 passed.
+- `dotnet test CShells.sln`: 607 CShells tests and 31 end-to-end tests passed.
+- `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -4,7 +4,10 @@
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~DynamicShellEndpointDataSource|FullyQualifiedName~ShellEndpointRegistrationHandler|FullyQualifiedName~ShellMiddleware"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~InvokeAsync_MatchedBeforeReload_UsesRoutingLeaseAcrossMiddlewareGap|FullyQualifiedName~MatcherPolicy_ReenteredThenShortCircuited_ReleasesSingleScopeOnCompletion"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_LaterSubscriberRejectsCandidate_RestoresPriorGeneration|FullyQualifiedName~Reload_MiddlewareCompositionFails_PreservesPriorGeneration|FullyQualifiedName~MethodsConflict_MethodCaseDiffers_ReturnsTrue|FullyQualifiedName~CompositionFailure_RejectsActivationWithoutPipeline"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_SlowLaterSubscriber_KeepsPriorGenerationRoutableUntilCommit|FullyQualifiedName~Reload_LaterParticipantRejectsCommit_RestoresPriorRoutesAndPipeline|FullyQualifiedName~Reload_CommitConflict_RestoresPriorActiveAndAllEntries|FullyQualifiedName~Reload_ParticipantCommitFailure_RestoresPriorRegistryStateAndRollsBackInReverse"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_OverlappingCommitAndRollback_DoesNotResurrectRoutes|FullyQualifiedName~PrepareGeneration_ConcurrentConflict_SecondCommitIsRejected|FullyQualifiedName~GetChangeToken_"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible|FullyQualifiedName~ActiveTransition_EndpointConflict_RemovesStagedPipeline|FullyQualifiedName~PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
@@ -17,18 +20,28 @@ feature assembly. It runs five cycles; each cycle loads the fixture into a colle
 the lifecycle handler's draining removal, calls `Unload`, and forces bounded full-GC passes.
 The assertion is on the `AssemblyLoadContext` `WeakReference`, so a published or retired
 endpoint delegate that still roots the fixture assembly fails the test.
+This is production route-builder/data-source retention evidence; it does not claim to exercise an
+attached server's matcher cache.
 
-The reload/drain integration test activates a real registry generation and sends a matched
-old-generation request into `ShellMiddleware` before `ReloadAsync` promotes the replacement. It
-then sends a new-generation request and verifies that each uses its exact pipeline. The old
-request's own scope is the only in-flight scope: drain does not complete until that response's
-`OnCompleted` callback releases it.
+The reload/drain integration tests activate real registry generations. One sends an old-generation
+request into `ShellMiddleware` before replacement; another acquires the endpoint generation in the
+matcher policy, pauses before middleware, completes the reload attempt, and then enters middleware.
+They verify old and new requests use their exact pipelines and the old request's own lease is the
+only in-flight scope: drain does not complete until that response's `OnCompleted` callback releases
+it. Policy re-entry and downstream short-circuiting retain the same single-lease guarantee.
 
-The rollback integration tests use the real registry and lifecycle subscriber chain. One rejects
-generation two after its endpoints and pipeline have been provisionally published, proving the
-generation-one endpoint snapshot and pipeline are restored. The other fails generation-two
-middleware composition before publication, proving activation is rejected without disturbing the
-prior generation. A focused route test preserves ordinal case-insensitive method overlap semantics.
+The rollback integration tests use the real registry and two-phase activation chain. A slow later
+subscriber proves its provisional candidate remains invisible. A participant registered after the
+endpoint handler rejects after endpoints commit, proving reverse rollback restores generation-one
+registry identity, routes, and pipeline. Another participant introduces a late host conflict and
+proves failed endpoint commit restores `Active`/`All`. Independent participants record reverse
+rollback ordering. Middleware composition fails during prepare without disturbing the prior
+generation, and a focused route test preserves ordinal case-insensitive method overlap semantics.
+
+Overlapping-publication tests commit several prepared same-shell transactions in adversarial order
+and prove stale rollback cannot resurrect an intermediate generation. Change-token tests race
+acquisition and publication repeatedly, proving returned tokens are never backed by an eagerly
+disposed source.
 
 The endpoint/pipeline ordering tests subscribe to the routing change token, which fires at the
 first externally visible publication point, and assert the exact generation pipeline is already
@@ -46,7 +59,9 @@ On 2026-08-16:
 - Transactional rollback, middleware rejection, method-case overlap, endpoint/pipeline ordering,
   ownership diagnostics, combined drain, and collectible-context regressions: 9 passed per
   invocation, repeated across 3 invocations.
-- Focused routing, lifecycle-handler, middleware, and activation regressions: 74 passed.
-- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 612 passed.
-- `dotnet test CShells.sln`: 612 CShells tests and 31 end-to-end tests passed.
+- Focused routing, lifecycle-handler, middleware, and activation regressions: 83 passed before the
+  final post-review additions.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 622 passed after the transaction and
+  routing-lease follow-up.
+- `dotnet test CShells.sln`: 622 CShells tests and 31 end-to-end tests passed.
 - `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -8,6 +8,7 @@ dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedNam
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_LaterSubscriberRejectsCandidate_RestoresPriorGeneration|FullyQualifiedName~Reload_MiddlewareCompositionFails_PreservesPriorGeneration|FullyQualifiedName~MethodsConflict_MethodCaseDiffers_ReturnsTrue|FullyQualifiedName~CompositionFailure_RejectsActivationWithoutPipeline"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~Reload_SlowLaterSubscriber_KeepsPriorGenerationRoutableUntilCommit|FullyQualifiedName~Reload_LaterParticipantRejectsCommit_RestoresPriorRoutesAndPipeline|FullyQualifiedName~Reload_CommitConflict_RestoresPriorActiveAndAllEntries|FullyQualifiedName~Reload_ParticipantCommitFailure_RestoresPriorRegistryStateAndRollsBackInReverse"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_OverlappingCommitAndRollback_DoesNotResurrectRoutes|FullyQualifiedName~PrepareGeneration_ConcurrentConflict_SecondCommitIsRejected|FullyQualifiedName~GetChangeToken_"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_Complete_AllowsNextCommit|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsSameShellMutations|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsCrossShellPublication|FullyQualifiedName~ColdStart_ReMatch_ConcurrentReload_KeepsMatchedGenerationLeased"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible|FullyQualifiedName~ActiveTransition_EndpointConflict_RemovesStagedPipeline|FullyQualifiedName~PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
@@ -39,9 +40,13 @@ rollback ordering. Middleware composition fails during prepare without disturbin
 generation, and a focused route test preserves ordinal case-insensitive method overlap semantics.
 
 Overlapping-publication tests commit several prepared same-shell transactions in adversarial order
-and prove stale rollback cannot resurrect an intermediate generation. Change-token tests race
+and prove stale rollback cannot resurrect an intermediate generation. Cross-shell and host-route
+tests prove the global collision inventory cannot mutate while rollback evidence is live, while
+explicit completion and rollback both release the next prepared commit. Change-token tests race
 acquisition and publication repeatedly, proving returned tokens are never backed by an eagerly
-disposed source.
+disposed source. A blocking endpoint-feature fixture pauses cold rematch exactly at endpoint
+exposure, performs a real concurrent reload, and proves the exact-generation lease holds drain until
+response completion.
 
 The endpoint/pipeline ordering tests subscribe to the routing change token, which fires at the
 first externally visible publication point, and assert the exact generation pipeline is already
@@ -59,9 +64,10 @@ On 2026-08-16:
 - Transactional rollback, middleware rejection, method-case overlap, endpoint/pipeline ordering,
   ownership diagnostics, combined drain, and collectible-context regressions: 9 passed per
   invocation, repeated across 3 invocations.
-- Focused routing, lifecycle-handler, middleware, and activation regressions: 83 passed before the
-  final post-review additions.
-- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 622 passed after the transaction and
-  routing-lease follow-up.
-- `dotnet test CShells.sln`: 622 CShells tests and 31 end-to-end tests passed.
+- Global transaction, cold-rematch, matched-before-middleware, and collectible-context regressions:
+  7 passed per invocation across 5 consecutive invocations.
+- Focused routing, lifecycle-handler, middleware, and activation regressions: 88 passed.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 626 passed after the global transaction
+  and cold-rematch follow-up.
+- `dotnet test CShells.sln`: 626 CShells tests and 31 end-to-end tests passed.
 - `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -10,6 +10,7 @@ dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedNam
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_OverlappingCommitAndRollback_DoesNotResurrectRoutes|FullyQualifiedName~PrepareGeneration_ConcurrentConflict_SecondCommitIsRejected|FullyQualifiedName~GetChangeToken_"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PrepareGeneration_Complete_AllowsNextCommit|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsSameShellMutations|FullyQualifiedName~PrepareGeneration_PendingCommit_GuardsCrossShellPublication|FullyQualifiedName~ColdStart_ReMatch_ConcurrentReload_KeepsMatchedGenerationLeased"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PendingCommit_OtherShellDrain_RemovesEndpointsAndReleasesReferences|FullyQualifiedName~PendingCommit_SameShellCandidateDrain_RestoresPriorGenerationWithoutStaleRoutes"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~PendingCommit_PriorGenerationDrainsThenCandidateRejects|FullyQualifiedName~PendingCommit_CandidateDrainsThenParticipantsAccept|FullyQualifiedName~Reload_CandidateDrainsDuringParticipantCompletion"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible|FullyQualifiedName~ActiveTransition_EndpointConflict_RemovesStagedPipeline|FullyQualifiedName~PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot"
 dotnet test tests/CShells.Tests/CShells.Tests.csproj
 dotnet build CShells.sln
@@ -55,6 +56,13 @@ endpoint object becomes collectible. The pending candidate itself is also draine
 before a later rejection, proving deferred generation cleanup neither corrupts rollback identity nor
 leaves candidate routes behind.
 
+The same-shell activation-finalization regressions drain generation one before a blocked candidate
+rejects, drain the candidate before a blocked participant accepts, and drain the candidate during
+participant completion. They prove rollback publishes its already-filtered final snapshot once,
+never restores a disposed prior generation, never returns a disposed candidate, and leaves either a
+live prior generation or an empty reactivatable slot. Each case finishes by driving a request through
+the recovered exact-generation middleware pipeline.
+
 The endpoint/pipeline ordering tests subscribe to the routing change token, which fires at the
 first externally visible publication point, and assert the exact generation pipeline is already
 available. A rejected-candidate companion test proves a staged pipeline is removed. Conflict tests
@@ -73,8 +81,10 @@ On 2026-08-16:
   invocation, repeated across 3 invocations.
 - Global transaction, lifecycle cleanup, cold-rematch, matched-before-middleware, and
   collectible-context regressions: 8 passed per invocation across 5 consecutive invocations.
-- Focused routing, lifecycle-handler, middleware, and activation regressions: 90 passed.
-- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 628 passed after the lifecycle-cleanup
+- Same-shell activation-finalization races: 3 passed per invocation across 5 consecutive
+  invocations.
+- Focused routing, lifecycle-handler, and middleware regressions: 82 passed.
+- `dotnet test tests/CShells.Tests/CShells.Tests.csproj`: 631 passed after the activation-finalization
   follow-up.
-- `dotnet test CShells.sln`: 628 CShells tests and 31 end-to-end tests passed.
+- `dotnet test CShells.sln`: 631 CShells tests and 31 end-to-end tests passed.
 - `dotnet build CShells.sln`: succeeded with 0 warnings and 0 errors.

--- a/specs/015-atomic-endpoint-generations/quickstart.md
+++ b/specs/015-atomic-endpoint-generations/quickstart.md
@@ -1,0 +1,7 @@
+# Verification
+
+```bash
+dotnet test tests/CShells.Tests/CShells.Tests.csproj --filter "FullyQualifiedName~DynamicShellEndpointDataSource|FullyQualifiedName~ShellEndpointRegistrationHandler|FullyQualifiedName~ShellMiddleware"
+dotnet test tests/CShells.Tests/CShells.Tests.csproj
+dotnet build CShells.sln
+```

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -46,10 +46,14 @@ owns the endpoint metadata.
    and all HTTP method comparisons use ordinal, case-insensitive semantics.
 8. A generation's middleware pipeline is available before its endpoint snapshot becomes visible;
    rejected endpoint publication removes the staged candidate pipeline.
-9. Overlapping prepared publications are linearizable. Rollback is transaction-specific and cannot
-   resurrect an intermediate generation after a newer same-shell publication wins.
+9. Overlapping preparation is allowed, but only one rollback-capable commit may be pending in the
+   route inventory. A second commit or any route/host inventory mutation is rejected until the
+   owner completes or rolls back the transaction. Rollback is transaction-specific and cannot
+   resurrect an intermediate generation or conflict with a cross-shell/host mutation.
 10. Endpoint change-token acquisition is race-safe with publication and does not expose a disposed
     token source or miss the snapshot change it is meant to observe.
+11. Cold-activation manual re-matching acquires the exact generation lease before exposing the
+    rematched endpoint, so a concurrent reload cannot dispose it in the handoff to middleware.
 
 ## Non-goals
 

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -50,12 +50,17 @@ owns the endpoint metadata.
    route inventory. A second commit and additive route/host inventory mutations are rejected until
    the owner completes or rolls back the transaction. Removals for other shells apply immediately;
    generation-specific cleanup for the pending shell is deferred and replayed idempotently during
-   completion or rollback. Rollback cannot resurrect an intermediate generation, conflict with an
-   addition, or prevent unrelated lifecycle cleanup.
+   completion or folded into the rollback snapshot before its single publication notification.
+   Rollback cannot transiently republish a disposed route, resurrect an intermediate generation,
+   conflict with an addition, or prevent unrelated lifecycle cleanup.
 10. Endpoint change-token acquisition is race-safe with publication and does not expose a disposed
     token source or miss the snapshot change it is meant to observe.
 11. Cold-activation manual re-matching acquires the exact generation lease before exposing the
     rematched endpoint, so a concurrent reload cannot dispose it in the handoff to middleware.
+12. Activation succeeds only while the candidate remains the registry's retained, exact Active
+    generation. Rejection restores a prior generation only when it is still Active and retained;
+    a candidate or prior generation drained during participant fan-out is never returned or
+    resurrected as Active, and a subsequent activation can recover a live serving generation.
 
 ## Non-goals
 

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -15,7 +15,8 @@ owns the endpoint metadata.
 - Build a complete shell generation endpoint candidate before publication.
 - Validate candidate routes against the existing host and shell route inventory.
 - Publish one immutable replacement snapshot per shell generation.
-- Preserve the previous snapshot if mapping or validation fails.
+- Preserve the previous snapshot if mapping, middleware composition, validation, or a later
+  activation subscriber fails.
 - Resolve matched requests by shell identifier and exact generation metadata.
 - Keep standard ASP.NET Core endpoint data sources and framework coexistence intact.
 - Exercise repeated replacement/removal/unload behavior with a real feature assembly loaded
@@ -25,7 +26,8 @@ owns the endpoint metadata.
 ## Functional requirements
 
 1. Conflicts are deterministic and identify both endpoint owners. Conflict detection is
-   conservative for equivalent route templates and overlapping HTTP method sets.
+   conservative for equivalent route templates and overlapping HTTP method sets. Dynamic owner
+   diagnostics include shell identifier, generation, and owning feature as structured data.
 2. Candidate validation occurs before the published endpoint snapshot changes.
 3. New requests see either the previous complete snapshot or the new complete snapshot;
    no intermediate empty state is published.
@@ -35,6 +37,13 @@ owns the endpoint metadata.
 5. Old endpoint generations can be removed during drain without removing the replacement,
    and drain completion waits for an in-flight old-generation request to release its
    `OnCompleted` scope.
+6. Candidate publication remains provisional until the prior generation begins normal
+   deactivation. If a later lifecycle subscriber rejects the candidate, the previous endpoint
+   snapshot and middleware pipeline remain live and the candidate is removed atomically.
+7. Middleware composition failure rejects activation instead of publishing a degraded pipeline,
+   and all HTTP method comparisons use ordinal, case-insensitive semantics.
+8. A generation's middleware pipeline is available before its endpoint snapshot becomes visible;
+   rejected endpoint publication removes the staged candidate pipeline.
 
 ## Non-goals
 

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -47,9 +47,11 @@ owns the endpoint metadata.
 8. A generation's middleware pipeline is available before its endpoint snapshot becomes visible;
    rejected endpoint publication removes the staged candidate pipeline.
 9. Overlapping preparation is allowed, but only one rollback-capable commit may be pending in the
-   route inventory. A second commit or any route/host inventory mutation is rejected until the
-   owner completes or rolls back the transaction. Rollback is transaction-specific and cannot
-   resurrect an intermediate generation or conflict with a cross-shell/host mutation.
+   route inventory. A second commit and additive route/host inventory mutations are rejected until
+   the owner completes or rolls back the transaction. Removals for other shells apply immediately;
+   generation-specific cleanup for the pending shell is deferred and replayed idempotently during
+   completion or rollback. Rollback cannot resurrect an intermediate generation, conflict with an
+   addition, or prevent unrelated lifecycle cleanup.
 10. Endpoint change-token acquisition is race-safe with publication and does not expose a disposed
     token source or miss the snapshot change it is meant to observe.
 11. Cold-activation manual re-matching acquires the exact generation lease before exposing the

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -32,18 +32,24 @@ owns the endpoint metadata.
 3. New requests see either the previous complete snapshot or the new complete snapshot;
    no intermediate empty state is published.
 4. A request with `ShellEndpointMetadata.Generation = N` uses generation N's shell scope
-   and middleware pipeline, even after generation N+1 is active; its scope remains held
-   until response completion.
+   and middleware pipeline, even when routing matched it before generation N+1 became active.
+   Routing acquires that exact-generation lease before the old generation can drain, and releases
+   it at response completion even if downstream middleware short-circuits.
 5. Old endpoint generations can be removed during drain without removing the replacement,
    and drain completion waits for an in-flight old-generation request to release its
    `OnCompleted` scope.
-6. Candidate publication remains provisional until the prior generation begins normal
-   deactivation. If a later lifecycle subscriber rejects the candidate, the previous endpoint
-   snapshot and middleware pipeline remain live and the candidate is removed atomically.
+6. Feature mapping, middleware composition, and route validation prepare an externally invisible
+   candidate. Lifecycle subscribers must accept it before the registry makes the candidate exactly
+   addressable and activation participants commit. A commit failure rolls participants back in
+   reverse order and atomically restores the prior registry, route, and pipeline state.
 7. Middleware composition failure rejects activation instead of publishing a degraded pipeline,
    and all HTTP method comparisons use ordinal, case-insensitive semantics.
 8. A generation's middleware pipeline is available before its endpoint snapshot becomes visible;
    rejected endpoint publication removes the staged candidate pipeline.
+9. Overlapping prepared publications are linearizable. Rollback is transaction-specific and cannot
+   resurrect an intermediate generation after a newer same-shell publication wins.
+10. Endpoint change-token acquisition is race-safe with publication and does not expose a disposed
+    token source or miss the snapshot change it is meant to observe.
 
 ## Non-goals
 

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -1,0 +1,39 @@
+# Atomic Shell Endpoint Generations
+
+## Problem
+
+Dynamic shell endpoints are currently removed and re-added during reload. A mapping
+failure can therefore leave a shell without its previous routes, and a successful
+replacement can expose an empty routing snapshot. The current collision check only
+compares the first HTTP method and raw route text, so equivalent parameter templates,
+multi-method routes, same-batch duplicates, and host/shell conflicts are not rejected.
+Requests matched before a reload must continue through the exact shell generation that
+owns the endpoint metadata.
+
+## Scope
+
+- Build a complete shell generation endpoint candidate before publication.
+- Validate candidate routes against the existing host and shell route inventory.
+- Publish one immutable replacement snapshot per shell generation.
+- Preserve the previous snapshot if mapping or validation fails.
+- Resolve matched requests by shell identifier and exact generation metadata.
+- Keep standard ASP.NET Core endpoint data sources and framework coexistence intact.
+- Exercise repeated reload/drain/unload behavior with collectible-context evidence where
+  the test fixture can load a feature assembly into a collectible `AssemblyLoadContext`.
+
+## Functional requirements
+
+1. Conflicts are deterministic and identify both endpoint owners. Conflict detection is
+   conservative for equivalent route templates and overlapping HTTP method sets.
+2. Candidate validation occurs before the published endpoint snapshot changes.
+3. New requests see either the previous complete snapshot or the new complete snapshot;
+   no intermediate empty state is published.
+4. A request with `ShellEndpointMetadata.Generation = N` uses generation N's shell scope
+   and middleware pipeline, even after generation N+1 is active.
+5. Old endpoint generations can be removed during drain without removing the replacement.
+
+## Non-goals
+
+- Replacing ASP.NET Core routing or adding a parallel endpoint framework.
+- Changing static host endpoint registration semantics.
+- Moving lifecycle policy or authorization rules into route-path middleware.

--- a/specs/015-atomic-endpoint-generations/spec.md
+++ b/specs/015-atomic-endpoint-generations/spec.md
@@ -18,8 +18,9 @@ owns the endpoint metadata.
 - Preserve the previous snapshot if mapping or validation fails.
 - Resolve matched requests by shell identifier and exact generation metadata.
 - Keep standard ASP.NET Core endpoint data sources and framework coexistence intact.
-- Exercise repeated reload/drain/unload behavior with collectible-context evidence where
-  the test fixture can load a feature assembly into a collectible `AssemblyLoadContext`.
+- Exercise repeated replacement/removal/unload behavior with a real feature assembly loaded
+  into a collectible `AssemblyLoadContext`; the test must prove that published and retired
+  endpoint delegates do not retain that context.
 
 ## Functional requirements
 
@@ -29,8 +30,11 @@ owns the endpoint metadata.
 3. New requests see either the previous complete snapshot or the new complete snapshot;
    no intermediate empty state is published.
 4. A request with `ShellEndpointMetadata.Generation = N` uses generation N's shell scope
-   and middleware pipeline, even after generation N+1 is active.
-5. Old endpoint generations can be removed during drain without removing the replacement.
+   and middleware pipeline, even after generation N+1 is active; its scope remains held
+   until response completion.
+5. Old endpoint generations can be removed during drain without removing the replacement,
+   and drain completion waits for an in-flight old-generation request to release its
+   `OnCompleted` scope.
 
 ## Non-goals
 

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -22,4 +22,10 @@
 
 - [x] T011 Run focused ASP.NET Core tests.
 - [x] T012 Run full CShells tests/build and diff review.
-- [x] T013 Perform self-review/fix iterations and leave a clean committed worktree.
+- [x] T013 Add transactional rollback when a later lifecycle subscriber rejects a provisionally
+  published generation.
+- [x] T014 Reject middleware-composition failures, compare HTTP methods case-insensitively, and
+  prove the combined in-flight reload/drain sequence without an independent guard scope.
+- [x] T015 Close the endpoint/pipeline visibility window and add structured shell, generation,
+  and feature conflict ownership.
+- [x] T016 Perform self-review/fix iterations and leave a clean committed worktree.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -5,8 +5,10 @@
 - [x] T001 Add route-owner metadata and conflict exception tests.
 - [x] T002 Add exact/equivalent/multi-method/same-batch/host conflict tests.
 - [x] T003 Add failed-candidate preservation and atomic replacement tests.
-- [x] T004 Add exact-generation middleware binding and drain coexistence tests.
-- [x] T005 Add repeated generation disposal/collectibility evidence test where supported.
+- [x] T004 Add a combined reload/drain test for exact-generation binding, replacement routing,
+  and `OnCompleted` scope release.
+- [x] T005 Add five-cycle collectible `AssemblyLoadContext` evidence through the production
+  route-builder/data-source publication and replacement/removal path.
 
 ## Phase 2 — implementation
 

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Atomic Shell Endpoint Generations
+
+## Phase 1 — tests and contracts
+
+- [x] T001 Add route-owner metadata and conflict exception tests.
+- [x] T002 Add exact/equivalent/multi-method/same-batch/host conflict tests.
+- [x] T003 Add failed-candidate preservation and atomic replacement tests.
+- [x] T004 Add exact-generation middleware binding and drain coexistence tests.
+- [x] T005 Add repeated generation disposal/collectibility evidence test where supported.
+
+## Phase 2 — implementation
+
+- [x] T006 Implement typed ownership metadata and deterministic diagnostics.
+- [x] T007 Implement candidate normalization, validation, and immutable publication.
+- [x] T008 Track feature ownership while mapping shell endpoints.
+- [x] T009 Stage middleware pipeline composition and commit it after publication.
+- [x] T010 Bind matched requests to exact endpoint generation.
+
+## Phase 3 — validation
+
+- [x] T011 Run focused ASP.NET Core tests.
+- [ ] T012 Run full CShells tests/build and diff review.
+- [ ] T013 Perform self-review/fix iterations and leave a clean committed worktree.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -42,3 +42,6 @@
   real-registry reload drains only after response completion.
 - [x] T023 Allow monotonic lifecycle cleanup during a pending global transaction, defer cleanup for
   its own generation, and prove cross-shell collection plus same-shell rollback under real drains.
+- [x] T024 Reject drained activation candidates, restore only eligible prior generations, fold
+  deferred drain cleanup into one rollback snapshot, and prove request-serving recovery for drains
+  that win during commit or completion.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -19,5 +19,5 @@
 ## Phase 3 — validation
 
 - [x] T011 Run focused ASP.NET Core tests.
-- [ ] T012 Run full CShells tests/build and diff review.
-- [ ] T013 Perform self-review/fix iterations and leave a clean committed worktree.
+- [x] T012 Run full CShells tests/build and diff review.
+- [x] T013 Perform self-review/fix iterations and leave a clean committed worktree.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -40,3 +40,5 @@
   same-shell, cross-shell, completion, and rollback transaction ordering.
 - [x] T022 Lease cold-activation manual rematches before endpoint exposure and prove a concurrent
   real-registry reload drains only after response completion.
+- [x] T023 Allow monotonic lifecycle cleanup during a pending global transaction, defer cleanup for
+  its own generation, and prove cross-shell collection plus same-shell rollback under real drains.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -36,3 +36,7 @@
 - [x] T019 Acquire an idempotent exact-generation routing lease before middleware handoff and prove
   matched-before-reload requests hold drain until response completion.
 - [x] T020 Linearize overlapping publications and make change-token acquisition race-safe.
+- [x] T021 Enforce one global rollback-capable publication, guard route/host mutations, and prove
+  same-shell, cross-shell, completion, and rollback transaction ordering.
+- [x] T022 Lease cold-activation manual rematches before endpoint exposure and prove a concurrent
+  real-registry reload drains only after response completion.

--- a/specs/015-atomic-endpoint-generations/tasks.md
+++ b/specs/015-atomic-endpoint-generations/tasks.md
@@ -29,3 +29,10 @@
 - [x] T015 Close the endpoint/pipeline visibility window and add structured shell, generation,
   and feature conflict ownership.
 - [x] T016 Perform self-review/fix iterations and leave a clean committed worktree.
+- [x] T017 Introduce an externally invisible two-phase activation boundary and prove provisional
+  subscriber fan-out never exposes the candidate to routing.
+- [x] T018 Make committed publication rollback transaction-specific and prove reverse rollback
+  restores prior registry, routes, and pipeline after a later participant rejects activation.
+- [x] T019 Acquire an idempotent exact-generation routing lease before middleware handoff and prove
+  matched-before-reload requests hold drain until response completion.
+- [x] T020 Linearize overlapping publications and make change-token acquisition race-safe.

--- a/src/CShells.Abstractions/Lifecycle/IShellGenerationActivationParticipant.cs
+++ b/src/CShells.Abstractions/Lifecycle/IShellGenerationActivationParticipant.cs
@@ -1,0 +1,30 @@
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Participates in the prepare/commit boundary for a shell generation becoming active.
+/// </summary>
+/// <remarks>
+/// Preparation runs before the Active lifecycle notification and must remain externally
+/// invisible. Commit runs only after subscribers accept the generation and the registry makes
+/// it exactly addressable. Rollback releases prepared state when either phase fails.
+/// </remarks>
+public interface IShellGenerationActivationParticipant
+{
+    /// <summary>Prepares generation-owned state without making it externally visible.</summary>
+    Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default);
+
+    /// <summary>Commits prepared state after the registry publishes the generation.</summary>
+    void Commit(IShell shell);
+
+    /// <summary>
+    /// Releases rollback state after every participant commits successfully. Completion is
+    /// best-effort cleanup and must not be used as an additional acceptance phase.
+    /// </summary>
+    void Complete(IShell shell);
+
+    /// <summary>
+    /// Discards prepared or partially committed state. Implementations must tolerate rollback
+    /// after their own preparation throws and repeated cleanup during shell disposal.
+    /// </summary>
+    void Rollback(IShell shell);
+}

--- a/src/CShells.Abstractions/Lifecycle/ShellGenerationActivationException.cs
+++ b/src/CShells.Abstractions/Lifecycle/ShellGenerationActivationException.cs
@@ -1,0 +1,24 @@
+namespace CShells.Lifecycle;
+
+/// <summary>
+/// Indicates that a shell generation could not be published during its activation transition.
+/// </summary>
+/// <remarks>
+/// Lifecycle subscribers normally cannot disrupt a transition because subscriber isolation is a
+/// framework invariant. Endpoint publication is the explicit exception: a rejected candidate must
+/// abort the candidate generation so a previous active generation can continue serving traffic.
+/// </remarks>
+public sealed class ShellGenerationActivationException : InvalidOperationException
+{
+    /// <summary>Initializes a new exception for the rejected shell generation.</summary>
+    /// <param name="descriptor">The rejected generation descriptor.</param>
+    /// <param name="innerException">The publication or mapping failure.</param>
+    public ShellGenerationActivationException(ShellDescriptor descriptor, Exception innerException)
+        : base($"Shell generation '{Guard.Against.Null(descriptor)}' could not be published.", Guard.Against.Null(innerException))
+    {
+        Descriptor = descriptor;
+    }
+
+    /// <summary>Gets the rejected generation descriptor.</summary>
+    public ShellDescriptor Descriptor { get; }
+}

--- a/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Configuration/CShellsBuilderExtensions.cs
@@ -7,6 +7,8 @@ using CShells.Lifecycle;
 using CShells.Resolution;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -210,6 +212,11 @@ public static class CShellsBuilderExtensions
             // and dispatched per request by ShellMiddleware
             builder.Services.TryAddSingleton<Middleware.ShellMiddlewarePipelineRegistry>();
 
+            // Acquire an exact-generation request scope inside endpoint matching, before a
+            // concurrent reload can dispose the generation selected by routing.
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<MatcherPolicy, ShellEndpointGenerationMatcherPolicy>());
+
             // Register the endpoint registration handler as a lifecycle subscriber. It
             // self-subscribes to IShellRegistry in its constructor and rebuilds endpoints on
             // Initializing → Active / tears them down on Deactivating.
@@ -217,6 +224,8 @@ public static class CShellsBuilderExtensions
             {
                 builder.Services.AddSingleton<Notifications.ShellEndpointRegistrationHandler>();
                 builder.Services.AddSingleton<IShellLifecycleSubscriber>(
+                    sp => sp.GetRequiredService<Notifications.ShellEndpointRegistrationHandler>());
+                builder.Services.AddSingleton<IShellGenerationActivationParticipant>(
                     sp => sp.GetRequiredService<Notifications.ShellEndpointRegistrationHandler>());
             }
 

--- a/src/CShells.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/CShells.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -70,6 +70,13 @@ public static class ApplicationBuilderExtensions
         // This makes all shell endpoints available to the routing system
         endpoints.DataSources.Add(endpointDataSource);
 
+        // Keep a host-only inventory for candidate collision validation. The dynamic source is
+        // intentionally excluded; its own immutable snapshot is validated separately.
+        endpointDataSource.SetHostEndpoints(
+            endpoints.DataSources
+                .Where(dataSource => !ReferenceEquals(dataSource, endpointDataSource))
+                .SelectMany(dataSource => dataSource.Endpoints));
+
         // Step 7: Replay registration for shells that activated before this call captured the
         // accessors (e.g. explicit warm-up activation in Program.cs before MapShells). Without
         // the replay those generations would permanently lack endpoints and middleware.

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -70,7 +70,7 @@ public class ShellMiddleware(
         if (endpointMetadata is not null)
         {
             var matchedShell = _registry.GetAll(endpointMetadata.ShellId.Name)
-                .FirstOrDefault(candidate => candidate.Descriptor.Generation == endpointMetadata.Generation)!;
+                .FirstOrDefault(candidate => candidate.Descriptor.Generation == endpointMetadata.Generation);
             if (matchedShell is null)
             {
                 _logger.LogWarning(

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -54,6 +54,9 @@ public class ShellMiddleware(
         // this request enters middleware, so resolving only by shell name would route the request
         // into the wrong provider. The endpoint generation is the binding authority.
         var endpointMetadata = context.GetEndpoint()?.Metadata.GetMetadata<ShellEndpointMetadata>();
+        var generationLease = context.Features.Get<ShellEndpointGenerationLease>();
+        if (endpointMetadata is null || generationLease?.Matches(endpointMetadata) != true)
+            generationLease = null;
         ShellId? shellId = endpointMetadata?.ShellId
             ?? await ResolveShellWithCacheAsync(context, resolutionContext, context.RequestAborted).ConfigureAwait(false);
 
@@ -69,8 +72,9 @@ public class ShellMiddleware(
         IShell shell;
         if (endpointMetadata is not null)
         {
-            var matchedShell = _registry.GetAll(endpointMetadata.ShellId.Name)
-                .FirstOrDefault(candidate => candidate.Descriptor.Generation == endpointMetadata.Generation);
+            var matchedShell = generationLease?.Scope.Shell
+                ?? _registry.GetAll(endpointMetadata.ShellId.Name)
+                    .FirstOrDefault(candidate => candidate.Descriptor.Generation == endpointMetadata.Generation);
             if (matchedShell is null)
             {
                 _logger.LogWarning(
@@ -135,9 +139,10 @@ public class ShellMiddleware(
         // `await using`) so upstream middleware can still read RequestServices during its
         // post-_next processing — releasing at InvokeAsync return could dispose the DI scope
         // out from under that post-processing and cause ObjectDisposedException.
-        var scope = shell.BeginScope();
+        var scope = generationLease?.Scope ?? shell.BeginScope();
         context.RequestServices = scope.ServiceProvider;
-        context.Response.OnCompleted(() => scope.DisposeAsync().AsTask());
+        if (generationLease is null)
+            context.Response.OnCompleted(() => scope.DisposeAsync().AsTask());
 
         await (pipeline ?? _next)(context);
     }

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -49,12 +49,12 @@ public class ShellMiddleware(
     {
         var resolutionContext = context.ToShellResolutionContext();
 
-        // Prefer the shell that owns the matched endpoint (set by UseRouting before this middleware).
-        // This guarantees that a shell-owned endpoint always executes inside the shell's scope,
-        // even when the general resolver pipeline would have picked a different default.
-        var endpointShellId = context.GetEndpoint()?.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId;
-
-        ShellId? shellId = endpointShellId
+        // Prefer the shell generation that owns the matched endpoint (set by UseRouting before
+        // this middleware). A reload may already have promoted a newer generation by the time
+        // this request enters middleware, so resolving only by shell name would route the request
+        // into the wrong provider. The endpoint generation is the binding authority.
+        var endpointMetadata = context.GetEndpoint()?.Metadata.GetMetadata<ShellEndpointMetadata>();
+        ShellId? shellId = endpointMetadata?.ShellId
             ?? await ResolveShellWithCacheAsync(context, resolutionContext, context.RequestAborted).ConfigureAwait(false);
 
         if (shellId is null)
@@ -66,37 +66,54 @@ public class ShellMiddleware(
 
         _logger.LogInformation("Resolved shell '{ShellId}' for request path '{Path}'", shellId.Value, context.Request.Path);
 
-        // Check whether the shell is already active so we can detect cold activation below.
-        var wasCold = _registry.GetActive(shellId.Value.Name) is null;
-
         IShell shell;
-        try
+        if (endpointMetadata is not null)
         {
-            // Lazy activation: GetOrActivateAsync returns the active generation if already live,
-            // otherwise looks up the blueprint via the provider, builds the shell, and publishes it.
-            // Stampede-safe — the per-name semaphore serializes concurrent cold-shell requests.
-            shell = await _registry.GetOrActivateAsync(shellId.Value.Name, context.RequestAborted);
-        }
-        catch (ShellBlueprintNotFoundException)
-        {
-            _logger.LogInformation("No blueprint registered for shell '{ShellId}'; returning 404.", shellId.Value);
-            context.Response.StatusCode = StatusCodes.Status404NotFound;
-            return;
-        }
-        catch (ShellBlueprintUnavailableException ex)
-        {
-            _logger.LogWarning(ex, "Blueprint provider unavailable for shell '{ShellId}'; returning 503.", shellId.Value);
-            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            return;
-        }
+            var matchedShell = _registry.GetAll(endpointMetadata.ShellId.Name)
+                .FirstOrDefault(candidate => candidate.Descriptor.Generation == endpointMetadata.Generation)!;
+            if (matchedShell is null)
+            {
+                _logger.LogWarning(
+                    "Matched endpoint for shell '{ShellId}' generation {Generation}, but that exact generation is no longer available.",
+                    endpointMetadata.ShellId, endpointMetadata.Generation);
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return;
+            }
 
-        // Cold activation: UseRouting() ran before this middleware and either found no endpoint,
-        // or selected a host fallback endpoint because shell endpoints had not been registered yet.
-        // Now that activation has completed and the ShellEndpointRegistrationHandler has published
-        // the shell's endpoints, re-match the request so downstream endpoint middleware can execute
-        // the shell handler instead of a preselected fallback.
-        if (wasCold && ShouldTryMatchEndpointAfterColdActivation(context.GetEndpoint()))
-            TryMatchEndpointAfterColdActivation(context, shellId.Value);
+            shell = matchedShell;
+        }
+        else
+        {
+            // Check whether the shell is already active so we can detect cold activation below.
+            var wasCold = _registry.GetActive(shellId.Value.Name) is null;
+            try
+            {
+                // Lazy activation: GetOrActivateAsync returns the active generation if already live,
+                // otherwise looks up the blueprint via the provider, builds the shell, and publishes it.
+                // Stampede-safe — the per-name semaphore serializes concurrent cold-shell requests.
+                shell = await _registry.GetOrActivateAsync(shellId.Value.Name, context.RequestAborted);
+            }
+            catch (ShellBlueprintNotFoundException)
+            {
+                _logger.LogInformation("No blueprint registered for shell '{ShellId}'; returning 404.", shellId.Value);
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+            catch (ShellBlueprintUnavailableException ex)
+            {
+                _logger.LogWarning(ex, "Blueprint provider unavailable for shell '{ShellId}'; returning 503.", shellId.Value);
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return;
+            }
+
+            // Cold activation: UseRouting() ran before this middleware and either found no endpoint,
+            // or selected a host fallback endpoint because shell endpoints had not been registered yet.
+            // Now that activation has completed and the ShellEndpointRegistrationHandler has published
+            // the shell's endpoints, re-match the request so downstream endpoint middleware can execute
+            // the shell handler instead of a preselected fallback.
+            if (wasCold && ShouldTryMatchEndpointAfterColdActivation(context.GetEndpoint()))
+                TryMatchEndpointAfterColdActivation(context, shellId.Value);
+        }
 
         // Resolve the shell's composed middleware pipeline BEFORE taking the scope. Ordering
         // matters: pipeline entries are removed when a generation reaches Disposed (bounded or

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -105,6 +105,12 @@ public class ShellMiddleware(
                 context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
                 return;
             }
+            catch (ShellGenerationActivationException ex)
+            {
+                _logger.LogWarning(ex, "Shell generation publication failed for '{ShellId}'; returning 503.", shellId.Value);
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return;
+            }
 
             // Cold activation: UseRouting() ran before this middleware and either found no endpoint,
             // or selected a host fallback endpoint because shell endpoints had not been registered yet.

--- a/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
+++ b/src/CShells.AspNetCore/Middleware/ShellMiddleware.cs
@@ -57,7 +57,7 @@ public class ShellMiddleware(
         var generationLease = context.Features.Get<ShellEndpointGenerationLease>();
         if (endpointMetadata is null || generationLease?.Matches(endpointMetadata) != true)
             generationLease = null;
-        ShellId? shellId = endpointMetadata?.ShellId
+        var shellId = endpointMetadata?.ShellId
             ?? await ResolveShellWithCacheAsync(context, resolutionContext, context.RequestAborted).ConfigureAwait(false);
 
         if (shellId is null)
@@ -122,7 +122,22 @@ public class ShellMiddleware(
             // the shell's endpoints, re-match the request so downstream endpoint middleware can execute
             // the shell handler instead of a preselected fallback.
             if (wasCold && ShouldTryMatchEndpointAfterColdActivation(context.GetEndpoint()))
-                TryMatchEndpointAfterColdActivation(context, shellId.Value);
+            {
+                generationLease = TryMatchEndpointAfterColdActivation(
+                    context,
+                    shellId.Value,
+                    shell,
+                    out var endpointMatched);
+                if (endpointMatched && generationLease is null)
+                {
+                    _logger.LogWarning(
+                        "Cold-start endpoint matched shell '{ShellId}' generation {Generation}, but that generation drained before the request could lease it.",
+                        shellId.Value,
+                        shell.Descriptor.Generation);
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    return;
+                }
+            }
         }
 
         // Resolve the shell's composed middleware pipeline BEFORE taking the scope. Ordering
@@ -203,15 +218,22 @@ public class ShellMiddleware(
     /// <see cref="DynamicShellEndpointDataSource"/>. Walk the data source and set the first
     /// matching endpoint on the context so the downstream endpoint middleware can execute it.
     /// </summary>
-    private void TryMatchEndpointAfterColdActivation(HttpContext context, ShellId shellId)
+    private ShellEndpointGenerationLease? TryMatchEndpointAfterColdActivation(
+        HttpContext context,
+        ShellId shellId,
+        IShell shell,
+        out bool endpointMatched)
     {
+        endpointMatched = false;
         foreach (var endpoint in _endpointDataSource.Endpoints)
         {
             if (endpoint is not RouteEndpoint routeEndpoint)
                 continue;
 
             var metadata = routeEndpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-            if (metadata is null || !metadata.ShellId.Equals(shellId))
+            if (metadata is null
+                || !metadata.ShellId.Equals(shellId)
+                || metadata.Generation != shell.Descriptor.Generation)
                 continue;
 
             // Check HTTP method constraint first (cheap).
@@ -239,13 +261,19 @@ public class ShellMiddleware(
             if (!ApplyInlineConstraints(routeEndpoint.RoutePattern, routeValues, context))
                 continue;
 
+            endpointMatched = true;
+            if (!ShellEndpointGenerationLease.TryAcquire(context, metadata, shell, out var lease))
+                return null;
+
             context.SetEndpoint(routeEndpoint);
             context.Request.RouteValues = routeValues;
             _logger.LogDebug(
                 "Cold-start re-matched endpoint '{Pattern}' for shell '{Shell}'",
                 routeEndpoint.RoutePattern.RawText, shellId);
-            return;
+            return lease;
         }
+
+        return null;
     }
 
     private static bool ApplyInlineConstraints(

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -94,7 +94,6 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
     {
         Guard.Against.Null(shell);
         _logger.LogInformation("Registering endpoints for active shell '{Shell}'", shell.Descriptor);
-        _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name));
         RegisterShellEndpoints(shell);
     }
 
@@ -103,6 +102,13 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var endpointRouteBuilder = _endpointRouteBuilderAccessor.EndpointRouteBuilder;
         if (endpointRouteBuilder is null)
             return;
+
+        // Refresh the standard host endpoint inventory immediately before mapping so candidate
+        // validation sees the same routes that ASP.NET Core will see after publication.
+        _endpointDataSource.SetHostEndpoints(
+            endpointRouteBuilder.DataSources
+                .SelectMany(dataSource => dataSource.Endpoints)
+                .Where(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null));
 
         var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
         _logger.LogDebug("Registering endpoints for shell '{Shell}' ({FeatureCount} config entries)",
@@ -129,24 +135,21 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var allFeatureDescriptors = shell.ServiceProvider.GetRequiredService<IEnumerable<ShellFeatureDescriptor>>().ToList();
         var featureContext = new ShellFeatureContext(settings, allFeatureDescriptors.AsReadOnly());
 
+        PipelineRegistration? pipelineRegistration;
         try
         {
-            RegisterShellMiddleware(settings, shell, allFeatureDescriptors, featureContext, shellPathPrefix);
+            pipelineRegistration = RegisterShellMiddleware(settings, shell, allFeatureDescriptors, featureContext, shellPathPrefix);
         }
         catch (Exception ex)
         {
-            // Fail closed. The lifecycle fan-out swallows subscriber exceptions, so rethrowing
-            // cannot fail the activation — the shell WILL go Active. A shell whose middleware
-            // could not be composed must not serve requests without it (the features may be
-            // auth- or dispatch-critical), so register a pipeline that rejects everything, and
-            // continue so endpoint registration still happens and requests get a diagnosable
-            // 503 instead of a silent 404.
+            // Middleware composition is staged with the endpoint candidate. Preserve the existing
+            // fail-closed behavior without publishing a pipeline until route validation succeeds.
             _logger.LogError(ex,
                 "Failed to compose the middleware pipeline for shell '{Shell}' generation {Generation}. " +
                 "The shell will respond 503 to all requests until it is successfully reloaded.",
                 shell.Descriptor, shell.Descriptor.Generation);
 
-            _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation,
+            pipelineRegistration = new PipelineRegistration(
                 context =>
                 {
                     context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
@@ -161,7 +164,12 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             try
             {
                 var feature = _featureFactory.CreateFeature<IWebShellFeature>(featureType, settings, featureContext);
+                var beforeMapping = shellEndpointBuilder.GetRawEndpoints().ToHashSet();
                 feature.MapEndpoints(shellEndpointBuilder, _environment);
+                var mappedEndpoints = shellEndpointBuilder.GetRawEndpoints()
+                    .Where(endpoint => !beforeMapping.Contains(endpoint))
+                    .ToList();
+                shellEndpointBuilder.AssignFeature(featureId, mappedEndpoints);
 
                 _logger.LogDebug("Mapped endpoints for feature '{FeatureId}' in shell '{Shell}'",
                     featureId, shell.Descriptor);
@@ -185,7 +193,16 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             }
         }
 
-        _endpointDataSource.AddEndpoints(shellEndpoints);
+        // Validate the complete candidate before replacing this shell's published snapshot.
+        // A conflict leaves the old generation available to both routing and in-flight calls.
+        _endpointDataSource.PublishGeneration(settings.Id, shell.Descriptor.Generation, shellEndpoints);
+
+        // Commit the staged middleware only after publication succeeds, avoiding a half-built
+        // pipeline when feature mapping or validation fails.
+        if (pipelineRegistration is not null)
+            _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation,
+                pipelineRegistration.Pipeline, pipelineRegistration.Continuation);
+
         _logger.LogDebug("Registered {Count} endpoint(s) for shell '{Shell}'", shellEndpoints.Count, shell.Descriptor);
     }
 
@@ -215,7 +232,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             .Select(d => (d.Id, d.StartupType!));
     }
 
-    private void RegisterShellMiddleware(
+    private PipelineRegistration? RegisterShellMiddleware(
         ShellSettings settings,
         IShell shell,
         IReadOnlyCollection<ShellFeatureDescriptor> allFeatureDescriptors,
@@ -226,7 +243,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         if (appBuilder is null)
         {
             _logger.LogDebug("IApplicationBuilder not available, skipping middleware registration for shell '{Shell}'", shell.Descriptor);
-            return;
+            return null;
         }
 
         var middlewareFeatures = new List<(string FeatureId, IMiddlewareShellFeature Feature)>();
@@ -244,7 +261,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         }
 
         if (middlewareFeatures.Count == 0)
-            return;
+            return null;
 
         _logger.LogInformation("Registering middleware for {Count} feature(s) in shell '{Shell}'",
             middlewareFeatures.Count, shell.Descriptor);
@@ -311,8 +328,10 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             builder.Run(context => continuation.Next(context));
         }
 
-        _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation, builder.Build(), continuation);
+        return new PipelineRegistration(builder.Build(), continuation);
     }
+
+    private sealed record PipelineRegistration(RequestDelegate Pipeline, ShellPipelineContinuation Continuation);
 
     private static string? GetPathPrefix(ShellSettings settings)
     {

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -76,20 +76,25 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             return Task.CompletedTask;
         }
 
-        if (current == ShellLifecycleState.Deactivating ||
-            current == ShellLifecycleState.Draining ||
-            current == ShellLifecycleState.Disposed)
+        if (current == ShellLifecycleState.Deactivating || current == ShellLifecycleState.Draining)
         {
             _logger.LogInformation("Removing endpoints for shell '{Shell}' generation {Generation} ({State})",
                 shell.Descriptor, shell.Descriptor.Generation, current);
-            _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+            _endpointDataSource.RetireGeneration(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+        }
+
+        if (current == ShellLifecycleState.Disposed)
+        {
+            // Rejected candidates advance directly from Active to Disposed before the prior
+            // generation deactivates. Roll that provisionally published candidate back atomically.
+            // A normal drain committed the replacement above, so this degrades to generation removal.
+            _endpointDataSource.RollbackGeneration(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
 
             // The middleware pipeline is removed only on disposal: unlike endpoints (which must
             // stop matching as soon as the generation deactivates), the pipeline is only looked
             // up by requests that already hold this generation's scope — and drain's scope-wait
             // keeps the generation from reaching Disposed while any such request is in flight.
-            if (current == ShellLifecycleState.Disposed)
-                _pipelineRegistry.Remove(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+            _pipelineRegistry.Remove(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
         }
 
         return Task.CompletedTask;
@@ -152,20 +157,11 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         }
         catch (Exception ex)
         {
-            // Middleware composition is staged with the endpoint candidate. Preserve the existing
-            // fail-closed behavior without publishing a pipeline until route validation succeeds.
             _logger.LogError(ex,
-                "Failed to compose the middleware pipeline for shell '{Shell}' generation {Generation}. " +
-                "The shell will respond 503 to all requests until it is successfully reloaded.",
+                "Failed to compose the middleware pipeline for shell '{Shell}' generation {Generation}; " +
+                "rejecting the candidate generation.",
                 shell.Descriptor, shell.Descriptor.Generation);
-
-            pipelineRegistration = new PipelineRegistration(
-                context =>
-                {
-                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                    return Task.CompletedTask;
-                },
-                new ShellPipelineContinuation());
+            throw;
         }
 
         var webFeatures = DiscoverWebFeatures(settings, allFeatureDescriptors);
@@ -203,15 +199,26 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             }
         }
 
-        // Validate the complete candidate before replacing this shell's published snapshot.
-        // A conflict leaves the old generation available to both routing and in-flight calls.
-        _endpointDataSource.PublishGeneration(settings.Id, shell.Descriptor.Generation, shellEndpoints);
-
-        // Commit the staged middleware only after publication succeeds, avoiding a half-built
-        // pipeline when feature mapping or validation fails.
+        // Make the staged pipeline available before its endpoints can become visible. Routing
+        // change callbacks run synchronously during publication, so publishing first would allow
+        // a matched request to bypass required shell middleware in that window.
         if (pipelineRegistration is not null)
             _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation,
                 pipelineRegistration.Pipeline, pipelineRegistration.Continuation);
+
+        try
+        {
+            // Validate the complete candidate before replacing this shell's published snapshot.
+            // A conflict leaves the old generation available to both routing and in-flight calls.
+            _endpointDataSource.PublishGeneration(settings.Id, shell.Descriptor.Generation, shellEndpoints);
+        }
+        catch
+        {
+            // The staged pipeline has no visible endpoints if publication fails.
+            if (pipelineRegistration is not null)
+                _pipelineRegistry.Remove(settings.Id, shell.Descriptor.Generation);
+            throw;
+        }
 
         _logger.LogDebug("Registered {Count} endpoint(s) for shell '{Shell}'", shellEndpoints.Count, shell.Descriptor);
     }

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CShells.AspNetCore.Features;
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
@@ -19,8 +20,11 @@ namespace CShells.AspNetCore.Notifications;
 /// <see cref="ShellMiddlewarePipelineRegistry"/>. Subscribed to the registry via
 /// <see cref="IShellLifecycleSubscriber"/>.
 /// </summary>
-public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
+public sealed class ShellEndpointRegistrationHandler :
+    IShellLifecycleSubscriber,
+    IShellGenerationActivationParticipant
 {
+    private readonly ConcurrentDictionary<(ShellId ShellId, int Generation), PreparedShellRegistration> _prepared = new();
     private readonly DynamicShellEndpointDataSource _endpointDataSource;
     private readonly EndpointRouteBuilderAccessor _endpointRouteBuilderAccessor;
     private readonly ApplicationBuilderAccessor _applicationBuilderAccessor;
@@ -48,33 +52,100 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
     }
 
     /// <inheritdoc />
-    public Task OnStateChangedAsync(IShell shell, ShellLifecycleState previous, ShellLifecycleState current, CancellationToken cancellationToken = default)
+    public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default)
     {
-        // Register when a shell becomes Active, tear down when it starts deactivating or draining.
-        if (previous == ShellLifecycleState.Initializing && current == ShellLifecycleState.Active)
+        Guard.Against.Null(shell);
+        if (_endpointRouteBuilderAccessor.EndpointRouteBuilder is null)
         {
-            if (_endpointRouteBuilderAccessor.EndpointRouteBuilder is null)
-            {
-                _logger.LogWarning(
-                    "Cannot register endpoints or middleware for shell '{Shell}': MapShells() has not run yet. " +
-                    "Registration is replayed when MapShells() captures the routing infrastructure.",
-                    shell.Descriptor);
-                return Task.CompletedTask;
-            }
-
-            try
-            {
-                RegisterActiveShell(shell);
-            }
-            catch (Exception ex)
-            {
-                // Endpoint publication is part of activation's candidate boundary. The registry
-                // treats this typed failure as a candidate rejection, disposes the new provider,
-                // and preserves the previous active generation.
-                throw new ShellGenerationActivationException(shell.Descriptor, ex);
-            }
+            _logger.LogWarning(
+                "Cannot prepare endpoints or middleware for shell '{Shell}': MapShells() has not run yet. " +
+                "Registration is replayed when MapShells() captures the routing infrastructure.",
+                shell.Descriptor);
             return Task.CompletedTask;
         }
+
+        var key = GetGenerationKey(shell);
+        try
+        {
+            var registration = PrepareShellRegistration(shell);
+            if (!_prepared.TryAdd(key, registration))
+            {
+                registration.Publication.Dispose();
+                throw new InvalidOperationException(
+                    $"Shell endpoint generation '{shell.Descriptor}' already has a prepared publication.");
+            }
+        }
+        catch (Exception ex) when (ex is not ShellGenerationActivationException)
+        {
+            throw new ShellGenerationActivationException(shell.Descriptor, ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Commit(IShell shell)
+    {
+        Guard.Against.Null(shell);
+        var key = GetGenerationKey(shell);
+        if (!_prepared.TryGetValue(key, out var registration))
+            return;
+
+        try
+        {
+            // Pipeline publication precedes the endpoint swap. The endpoint data source change
+            // notification is the first point routing can observe this generation.
+            if (registration.Pipeline is not null)
+            {
+                _pipelineRegistry.Set(
+                    key.ShellId,
+                    key.Generation,
+                    registration.Pipeline.Pipeline,
+                    registration.Pipeline.Continuation);
+            }
+
+            RefreshHostEndpoints();
+            registration.Publication.Commit();
+        }
+        catch
+        {
+            _pipelineRegistry.Remove(key.ShellId, key.Generation);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Complete(IShell shell)
+    {
+        Guard.Against.Null(shell);
+        var key = GetGenerationKey(shell);
+        if (!_prepared.TryRemove(key, out var registration))
+            return;
+
+        registration.Publication.Complete();
+        registration.Publication.Dispose();
+    }
+
+    /// <inheritdoc />
+    public void Rollback(IShell shell)
+    {
+        Guard.Against.Null(shell);
+        var key = GetGenerationKey(shell);
+        if (_prepared.TryRemove(key, out var registration))
+        {
+            registration.Publication.Rollback();
+            registration.Publication.Dispose();
+        }
+        _pipelineRegistry.Remove(key.ShellId, key.Generation);
+    }
+
+    /// <inheritdoc />
+    public Task OnStateChangedAsync(IShell shell, ShellLifecycleState previous, ShellLifecycleState current, CancellationToken cancellationToken = default)
+    {
+        // Activation publication is coordinated through IShellGenerationActivationParticipant.
+        // Lifecycle notifications only own teardown.
+        if (previous == ShellLifecycleState.Initializing && current == ShellLifecycleState.Active)
+            return Task.CompletedTask;
 
         if (current == ShellLifecycleState.Deactivating || current == ShellLifecycleState.Draining)
         {
@@ -85,10 +156,8 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
 
         if (current == ShellLifecycleState.Disposed)
         {
-            // Rejected candidates advance directly from Active to Disposed before the prior
-            // generation deactivates. Roll that provisionally published candidate back atomically.
-            // A normal drain committed the replacement above, so this degrades to generation removal.
-            _endpointDataSource.RollbackGeneration(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+            Rollback(shell);
+            _endpointDataSource.RemoveEndpoints(new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
 
             // The middleware pipeline is removed only on disposal: unlike endpoints (which must
             // stop matching as soon as the generation deactivates), the pipeline is only looked
@@ -109,21 +178,26 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
     {
         Guard.Against.Null(shell);
         _logger.LogInformation("Registering endpoints for active shell '{Shell}'", shell.Descriptor);
-        RegisterShellEndpoints(shell);
+        try
+        {
+            PrepareAsync(shell).GetAwaiter().GetResult();
+            Commit(shell);
+            Complete(shell);
+        }
+        catch
+        {
+            Rollback(shell);
+            throw;
+        }
     }
 
-    private void RegisterShellEndpoints(IShell shell)
+    private PreparedShellRegistration PrepareShellRegistration(IShell shell)
     {
         var endpointRouteBuilder = _endpointRouteBuilderAccessor.EndpointRouteBuilder;
         if (endpointRouteBuilder is null)
-            return;
+            throw new InvalidOperationException("Endpoint routing infrastructure is not available.");
 
-        // Refresh the standard host endpoint inventory immediately before mapping so candidate
-        // validation sees the same routes that ASP.NET Core will see after publication.
-        _endpointDataSource.SetHostEndpoints(
-            endpointRouteBuilder.DataSources
-                .SelectMany(dataSource => dataSource.Endpoints)
-                .Where(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null));
+        RefreshHostEndpoints();
 
         var settings = shell.ServiceProvider.GetRequiredService<ShellSettings>();
         _logger.LogDebug("Registering endpoints for shell '{Shell}' ({FeatureCount} config entries)",
@@ -150,7 +224,7 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
         var allFeatureDescriptors = shell.ServiceProvider.GetRequiredService<IEnumerable<ShellFeatureDescriptor>>().ToList();
         var featureContext = new ShellFeatureContext(settings, allFeatureDescriptors.AsReadOnly());
 
-        PipelineRegistration? pipelineRegistration;
+        var pipelineRegistration = (PipelineRegistration?)null;
         try
         {
             pipelineRegistration = RegisterShellMiddleware(settings, shell, allFeatureDescriptors, featureContext, shellPathPrefix);
@@ -199,28 +273,11 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
             }
         }
 
-        // Make the staged pipeline available before its endpoints can become visible. Routing
-        // change callbacks run synchronously during publication, so publishing first would allow
-        // a matched request to bypass required shell middleware in that window.
-        if (pipelineRegistration is not null)
-            _pipelineRegistry.Set(settings.Id, shell.Descriptor.Generation,
-                pipelineRegistration.Pipeline, pipelineRegistration.Continuation);
-
-        try
-        {
-            // Validate the complete candidate before replacing this shell's published snapshot.
-            // A conflict leaves the old generation available to both routing and in-flight calls.
-            _endpointDataSource.PublishGeneration(settings.Id, shell.Descriptor.Generation, shellEndpoints);
-        }
-        catch
-        {
-            // The staged pipeline has no visible endpoints if publication fails.
-            if (pipelineRegistration is not null)
-                _pipelineRegistry.Remove(settings.Id, shell.Descriptor.Generation);
-            throw;
-        }
-
-        _logger.LogDebug("Registered {Count} endpoint(s) for shell '{Shell}'", shellEndpoints.Count, shell.Descriptor);
+        var publication = _endpointDataSource.PrepareGeneration(
+            settings.Id,
+            shell.Descriptor.Generation,
+            shellEndpoints);
+        return new PreparedShellRegistration(publication, pipelineRegistration);
     }
 
     private static IEnumerable<(string FeatureId, Type FeatureType)> DiscoverWebFeatures(
@@ -347,6 +404,25 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
 
         return new PipelineRegistration(builder.Build(), continuation);
     }
+
+    private void RefreshHostEndpoints()
+    {
+        var endpointRouteBuilder = _endpointRouteBuilderAccessor.EndpointRouteBuilder;
+        if (endpointRouteBuilder is null)
+            return;
+
+        _endpointDataSource.SetHostEndpoints(
+            endpointRouteBuilder.DataSources
+                .SelectMany(dataSource => dataSource.Endpoints)
+                .Where(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null));
+    }
+
+    private static (ShellId ShellId, int Generation) GetGenerationKey(IShell shell) =>
+        (new ShellId(shell.Descriptor.Name), shell.Descriptor.Generation);
+
+    private sealed record PreparedShellRegistration(
+        DynamicShellEndpointDataSource.ShellEndpointGenerationPublication Publication,
+        PipelineRegistration? Pipeline);
 
     private sealed record PipelineRegistration(RequestDelegate Pipeline, ShellPipelineContinuation Continuation);
 

--- a/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
+++ b/src/CShells.AspNetCore/Notifications/ShellEndpointRegistrationHandler.cs
@@ -62,7 +62,17 @@ public sealed class ShellEndpointRegistrationHandler : IShellLifecycleSubscriber
                 return Task.CompletedTask;
             }
 
-            RegisterActiveShell(shell);
+            try
+            {
+                RegisterActiveShell(shell);
+            }
+            catch (Exception ex)
+            {
+                // Endpoint publication is part of activation's candidate boundary. The registry
+                // treats this typed failure as a candidate rejection, disposes the new provider,
+                // and preserves the previous active generation.
+                throw new ShellGenerationActivationException(shell.Descriptor, ex);
+            }
             return Task.CompletedTask;
         }
 

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -15,6 +15,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
 {
     private IReadOnlyList<Endpoint> _publishedEndpoints = [];
     private IReadOnlyList<Endpoint> _hostEndpoints = [];
+    private readonly Dictionary<ShellId, PendingGenerationReplacement> _pendingReplacements = [];
     private readonly object _publicationLock = new();
     private CancellationTokenSource _cts = new();
     private readonly ILogger<DynamicShellEndpointDataSource> _logger = logger ?? NullLogger<DynamicShellEndpointDataSource>.Instance;
@@ -74,14 +75,63 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             ValidateCandidate(candidate, shellId, allowSameShellGenerations: false);
 
             var published = Volatile.Read(ref _publishedEndpoints);
+            var retired = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is not null && metadata.ShellId.Equals(shellId);
+            }).ToArray();
             var retained = published.Where(endpoint =>
             {
                 var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
                 return metadata is null || !metadata.ShellId.Equals(shellId);
             });
 
+            _pendingReplacements[shellId] = new PendingGenerationReplacement(generation, retired);
             Volatile.Write(ref _publishedEndpoints, [..retained, ..candidate]);
             NotifyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Retires a generation during normal deactivation. This commits any pending replacement
+    /// transaction involving that generation and removes its published endpoints.
+    /// </summary>
+    internal void RetireGeneration(ShellId shellId, int generation)
+    {
+        lock (_publicationLock)
+        {
+            CommitPendingReplacement(shellId, generation);
+            RemoveGeneration(shellId, generation, Volatile.Read(ref _publishedEndpoints));
+        }
+    }
+
+    /// <summary>
+    /// Rejects a candidate generation. When the generation still owns a pending replacement,
+    /// its retired endpoint snapshot is restored atomically; otherwise only that generation is removed.
+    /// </summary>
+    internal void RollbackGeneration(ShellId shellId, int generation)
+    {
+        lock (_publicationLock)
+        {
+            var published = Volatile.Read(ref _publishedEndpoints);
+            if (_pendingReplacements.TryGetValue(shellId, out var pending) && pending.CandidateGeneration == generation)
+            {
+                var retained = published.Where(endpoint =>
+                {
+                    var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                    return metadata is null || !metadata.ShellId.Equals(shellId);
+                });
+                var changed = pending.RetiredEndpoints.Count > 0 || published.Any(endpoint =>
+                    endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) == true);
+
+                _pendingReplacements.Remove(shellId);
+                Volatile.Write(ref _publishedEndpoints, [..retained, ..pending.RetiredEndpoints]);
+                if (changed)
+                    NotifyChanged();
+                return;
+            }
+
+            RemoveGeneration(shellId, generation, published);
         }
     }
 
@@ -104,6 +154,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            _pendingReplacements.Remove(shellId);
             var published = Volatile.Read(ref _publishedEndpoints);
             var retained = published.Where(endpoint =>
             {
@@ -125,17 +176,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            CommitPendingReplacement(shellId, generation);
             var published = Volatile.Read(ref _publishedEndpoints);
-            var retained = published.Where(endpoint =>
-            {
-                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-                return metadata is null || !metadata.ShellId.Equals(shellId) || metadata.Generation != generation;
-            }).ToArray();
-            if (retained.Length != published.Count)
-            {
-                Volatile.Write(ref _publishedEndpoints, retained);
-                NotifyChanged();
-            }
+            RemoveGeneration(shellId, generation, published);
         }
     }
 
@@ -146,6 +189,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            _pendingReplacements.Clear();
             var published = Volatile.Read(ref _publishedEndpoints);
             if (published.Count == 0)
                 return;
@@ -228,10 +272,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         string.Equals(NormalizePattern(candidate.RoutePattern), NormalizePattern(existing.RoutePattern), StringComparison.OrdinalIgnoreCase)
         && MethodsConflict(GetMethods(candidate), GetMethods(existing));
 
-    private static bool MethodsConflict(IReadOnlyCollection<string> candidate, IReadOnlyCollection<string> existing) =>
+    internal static bool MethodsConflict(IReadOnlyCollection<string> candidate, IReadOnlyCollection<string> existing) =>
         candidate.Contains("*", StringComparer.OrdinalIgnoreCase)
         || existing.Contains("*", StringComparer.OrdinalIgnoreCase)
-        || candidate.Any(existing.Contains);
+        || candidate.Any(method => existing.Contains(method, StringComparer.OrdinalIgnoreCase));
 
     private static IReadOnlyList<string> GetMethods(RouteEndpoint endpoint)
     {
@@ -268,21 +312,48 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             existing.RoutePattern.RawText ?? string.Empty);
     }
 
-    private static string DescribeOwner(Endpoint endpoint)
+    private static EndpointOwnershipMetadata DescribeOwner(Endpoint endpoint)
     {
         var ownership = endpoint.Metadata.GetMetadata<EndpointOwnershipMetadata>();
         if (ownership is not null)
-            return $"{ownership.OwnerKind}:{ownership.OwnerId}";
+            return ownership;
 
         var shell = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
         if (shell is not null)
-            return $"{shell.OwnerKind}:{shell.OwnerId}";
+            return new EndpointOwnershipMetadata(shell.OwnerKind, shell.OwnerId, shell.ShellId, shell.Generation);
 
-        return $"Host:{endpoint.DisplayName ?? "(unnamed endpoint)"}";
+        return new EndpointOwnershipMetadata(
+            EndpointOwnerKind.Host,
+            endpoint.DisplayName ?? "(unnamed endpoint)");
     }
 
     private static bool IsHostEndpoint(Endpoint endpoint) =>
         endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null;
+
+    private void CommitPendingReplacement(ShellId shellId, int generation)
+    {
+        if (!_pendingReplacements.TryGetValue(shellId, out var pending))
+            return;
+
+        var retiresGeneration = pending.RetiredEndpoints.Any(endpoint =>
+            endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.Generation == generation);
+        if (pending.CandidateGeneration == generation || retiresGeneration)
+            _pendingReplacements.Remove(shellId);
+    }
+
+    private void RemoveGeneration(ShellId shellId, int generation, IReadOnlyList<Endpoint> published)
+    {
+        var retained = published.Where(endpoint =>
+        {
+            var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+            return metadata is null || !metadata.ShellId.Equals(shellId) || metadata.Generation != generation;
+        }).ToArray();
+        if (retained.Length == published.Count)
+            return;
+
+        Volatile.Write(ref _publishedEndpoints, retained);
+        NotifyChanged();
+    }
 
     private void NotifyChanged()
     {
@@ -291,4 +362,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         oldCts.Cancel();
         oldCts.Dispose();
     }
+
+    private sealed record PendingGenerationReplacement(
+        int CandidateGeneration,
+        IReadOnlyList<Endpoint> RetiredEndpoints);
 }

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
@@ -12,19 +13,16 @@ namespace CShells.AspNetCore.Routing;
 /// </summary>
 public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSource>? logger = null) : EndpointDataSource
 {
-    private readonly List<Endpoint> _endpoints = [];
-    private readonly object _lock = new();
+    private IReadOnlyList<Endpoint> _publishedEndpoints = [];
+    private IReadOnlyList<Endpoint> _hostEndpoints = [];
+    private readonly object _publicationLock = new();
     private CancellationTokenSource _cts = new();
     private readonly ILogger<DynamicShellEndpointDataSource> _logger = logger ?? NullLogger<DynamicShellEndpointDataSource>.Instance;
 
     /// <inheritdoc />
     public override IReadOnlyList<Endpoint> Endpoints
     {
-        get
-        {
-            lock (_lock)
-                return [.._endpoints];
-        }
+        get => Volatile.Read(ref _publishedEndpoints);
     }
 
     /// <inheritdoc />
@@ -35,16 +33,68 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     /// </summary>
     public void AddEndpoints(IEnumerable<Endpoint> endpoints)
     {
-        lock (_lock)
-        {
-            var newEndpoints = endpoints.ToList();
-            if (newEndpoints.Count == 0)
-                return;
+        Guard.Against.Null(endpoints);
+        var additions = endpoints.ToArray();
+        if (additions.Length == 0)
+            return;
 
-            DetectPathConflicts(newEndpoints);
-            _endpoints.AddRange(newEndpoints);
+        lock (_publicationLock)
+        {
+            ValidateCandidate(additions, existingShellId: null, allowSameShellGenerations: true);
+            var published = Volatile.Read(ref _publishedEndpoints);
+            Volatile.Write(ref _publishedEndpoints, [..published, ..additions]);
             NotifyChanged();
         }
+    }
+
+    /// <summary>
+    /// Replaces every published generation for a shell with one validated candidate snapshot.
+    /// Validation completes before the snapshot changes, so a rejected candidate leaves the
+    /// previous generation available and a successful replacement never publishes an empty state.
+    /// </summary>
+    /// <param name="shellId">The shell whose generation is being replaced.</param>
+    /// <param name="generation">The candidate generation number.</param>
+    /// <param name="endpoints">The complete mapped endpoint candidate.</param>
+    /// <param name="hostEndpoints">Optional current host endpoint snapshot for collision checks.</param>
+    public void PublishGeneration(
+        ShellId shellId,
+        int generation,
+        IEnumerable<Endpoint> endpoints,
+        IEnumerable<Endpoint>? hostEndpoints = null)
+    {
+        Guard.Against.Null(endpoints);
+        var candidate = endpoints.ToArray();
+
+        lock (_publicationLock)
+        {
+            if (hostEndpoints is not null)
+                _hostEndpoints = hostEndpoints.Where(IsHostEndpoint).ToArray();
+
+            ValidateGenerationIdentity(shellId, generation, candidate);
+            ValidateCandidate(candidate, shellId, allowSameShellGenerations: false);
+
+            var published = Volatile.Read(ref _publishedEndpoints);
+            var retained = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(shellId);
+            });
+
+            Volatile.Write(ref _publishedEndpoints, [..retained, ..candidate]);
+            NotifyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Updates the host endpoint snapshot used by candidate collision validation.
+    /// Shell-owned endpoints are ignored automatically.
+    /// </summary>
+    /// <param name="endpoints">The standard ASP.NET Core host endpoint inventory.</param>
+    public void SetHostEndpoints(IEnumerable<Endpoint> endpoints)
+    {
+        Guard.Against.Null(endpoints);
+        lock (_publicationLock)
+            _hostEndpoints = endpoints.Where(IsHostEndpoint).ToArray();
     }
 
     /// <summary>
@@ -52,11 +102,19 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     /// </summary>
     public void RemoveEndpoints(ShellId shellId)
     {
-        lock (_lock)
+        lock (_publicationLock)
         {
-            var removed = _endpoints.RemoveAll(e => e.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) ?? false);
-            if (removed > 0)
+            var published = Volatile.Read(ref _publishedEndpoints);
+            var retained = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(shellId);
+            }).ToArray();
+            if (retained.Length != published.Count)
+            {
+                Volatile.Write(ref _publishedEndpoints, retained);
                 NotifyChanged();
+            }
         }
     }
 
@@ -65,15 +123,19 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     /// </summary>
     public void RemoveEndpoints(ShellId shellId, int generation)
     {
-        lock (_lock)
+        lock (_publicationLock)
         {
-            var removed = _endpoints.RemoveAll(e =>
+            var published = Volatile.Read(ref _publishedEndpoints);
+            var retained = published.Where(endpoint =>
             {
-                var meta = e.Metadata.GetMetadata<ShellEndpointMetadata>();
-                return meta is not null && meta.ShellId.Equals(shellId) && meta.Generation == generation;
-            });
-            if (removed > 0)
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(shellId) || metadata.Generation != generation;
+            }).ToArray();
+            if (retained.Length != published.Count)
+            {
+                Volatile.Write(ref _publishedEndpoints, retained);
                 NotifyChanged();
+            }
         }
     }
 
@@ -82,56 +144,145 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     /// </summary>
     public void Clear()
     {
-        lock (_lock)
+        lock (_publicationLock)
         {
-            if (_endpoints.Count == 0)
+            var published = Volatile.Read(ref _publishedEndpoints);
+            if (published.Count == 0)
                 return;
 
-            _endpoints.Clear();
+            Volatile.Write(ref _publishedEndpoints, []);
             NotifyChanged();
         }
     }
 
-    private void DetectPathConflicts(List<Endpoint> newEndpoints)
+    private void ValidateCandidate(
+        IReadOnlyList<Endpoint> candidate,
+        ShellId? existingShellId,
+        bool allowSameShellGenerations)
     {
-        foreach (var newEndpoint in newEndpoints.OfType<RouteEndpoint>())
-        {
-            var newPattern = newEndpoint.RoutePattern.RawText ?? "";
-            var newMethod = newEndpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods.FirstOrDefault() ?? "ANY";
-            var newShellMetadata = newEndpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-
-            foreach (var existingEndpoint in _endpoints.OfType<RouteEndpoint>())
+        var published = Volatile.Read(ref _publishedEndpoints);
+        var candidateShellIds = candidate
+            .Select(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId)
+            .OfType<ShellId>()
+            .ToHashSet();
+        var candidateGenerations = candidate
+            .Select(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>())
+            .Where(metadata => metadata is not null)
+            .GroupBy(metadata => metadata!.ShellId)
+            .ToDictionary(group => group.Key, group => group.Select(metadata => metadata!.Generation).ToHashSet());
+        var existing = published
+            .Concat(Volatile.Read(ref _hostEndpoints))
+            .Where(endpoint =>
             {
-                var existingPattern = existingEndpoint.RoutePattern.RawText ?? "";
-                var existingMethod = existingEndpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods.FirstOrDefault() ?? "ANY";
-                var existingShellMetadata = existingEndpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                if (existingShellId is null && allowSameShellGenerations)
+                {
+                    var existingMetadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                    return existingMetadata is null
+                           || !candidateShellIds.Contains(existingMetadata.ShellId)
+                           || candidateGenerations[existingMetadata.ShellId].Contains(existingMetadata.Generation);
+                }
 
-                if (!PatternsConflict(newPattern, existingPattern) || !MethodsConflict(newMethod, existingMethod))
+                if (existingShellId is null)
+                    return true;
+
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(existingShellId);
+            })
+            .OfType<RouteEndpoint>()
+            .ToArray();
+
+        var candidateRoutes = candidate.OfType<RouteEndpoint>().ToArray();
+        for (var i = 0; i < candidateRoutes.Length; i++)
+        {
+            var candidateEndpoint = candidateRoutes[i];
+            foreach (var existingEndpoint in existing.Concat(candidateRoutes.Take(i)))
+            {
+                if (!RoutesConflict(candidateEndpoint, existingEndpoint))
                     continue;
 
-                if (newShellMetadata != null && existingShellMetadata != null)
-                {
-                    _logger.LogWarning(
-                        "Path conflict detected: Shell '{NewShell}' endpoint '{NewMethod} {NewPattern}' conflicts with shell '{ExistingShell}' endpoint '{ExistingMethod} {ExistingPattern}'.",
-                        newShellMetadata.ShellId, newMethod, newPattern,
-                        existingShellMetadata.ShellId, existingMethod, existingPattern);
-                }
-                else if (newShellMetadata != null)
-                {
-                    _logger.LogWarning(
-                        "Path conflict detected: Shell '{NewShell}' endpoint '{NewMethod} {NewPattern}' conflicts with host application endpoint '{ExistingMethod} {ExistingPattern}'.",
-                        newShellMetadata.ShellId, newMethod, newPattern, existingMethod, existingPattern);
-                }
+                var conflict = BuildConflict(candidateEndpoint, existingEndpoint);
+                _logger.LogError("{Message}", new ShellEndpointConflictException(conflict).Message);
+                throw new ShellEndpointConflictException(conflict);
             }
         }
     }
 
-    private static bool PatternsConflict(string pattern1, string pattern2) =>
-        string.Equals(pattern1, pattern2, StringComparison.OrdinalIgnoreCase) ||
-        (string.IsNullOrEmpty(pattern1) && string.IsNullOrEmpty(pattern2));
+    private static void ValidateGenerationIdentity(ShellId shellId, int generation, IEnumerable<Endpoint> candidate)
+    {
+        foreach (var endpoint in candidate)
+        {
+            var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+            if (metadata is null)
+                continue;
 
-    private static bool MethodsConflict(string method1, string method2) =>
-        method1 == "ANY" || method2 == "ANY" || string.Equals(method1, method2, StringComparison.OrdinalIgnoreCase);
+            if (!metadata.ShellId.Equals(shellId) || metadata.Generation != generation)
+            {
+                throw new InvalidOperationException(
+                    $"Endpoint candidate metadata identifies shell '{metadata.ShellId}' generation {metadata.Generation}, " +
+                    $"but publication targets shell '{shellId}' generation {generation}.");
+            }
+        }
+    }
+
+    private static bool RoutesConflict(RouteEndpoint candidate, RouteEndpoint existing) =>
+        string.Equals(NormalizePattern(candidate.RoutePattern), NormalizePattern(existing.RoutePattern), StringComparison.OrdinalIgnoreCase)
+        && MethodsConflict(GetMethods(candidate), GetMethods(existing));
+
+    private static bool MethodsConflict(IReadOnlyCollection<string> candidate, IReadOnlyCollection<string> existing) =>
+        candidate.Contains("*", StringComparer.OrdinalIgnoreCase)
+        || existing.Contains("*", StringComparer.OrdinalIgnoreCase)
+        || candidate.Any(existing.Contains);
+
+    private static IReadOnlyList<string> GetMethods(RouteEndpoint endpoint)
+    {
+        var methods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
+        return methods is null || methods.Count == 0 ? ["*"] : methods.OrderBy(method => method, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static string NormalizePattern(RoutePattern pattern)
+    {
+        var segments = pattern.PathSegments.Select(segment => string.Concat(segment.Parts.Select(NormalizePart)));
+        return "/" + string.Join("/", segments);
+    }
+
+    private static string NormalizePart(RoutePatternPart part) => part switch
+    {
+        RoutePatternLiteralPart literal => literal.Content.ToLowerInvariant(),
+        RoutePatternParameterPart parameter => "{" +
+                                               (parameter.IsCatchAll ? "**" : parameter.IsOptional ? "?" : "") +
+                                               string.Join(",", parameter.ParameterPolicies.Select(policy => policy.Content?.ToLowerInvariant() ?? string.Empty)) +
+                                               "}",
+        _ => part.ToString()?.ToLowerInvariant() ?? string.Empty,
+    };
+
+    private static ShellEndpointConflict BuildConflict(RouteEndpoint candidate, RouteEndpoint existing)
+    {
+        var candidateOwner = DescribeOwner(candidate);
+        var existingOwner = DescribeOwner(existing);
+        return new ShellEndpointConflict(
+            candidateOwner,
+            existingOwner,
+            GetMethods(candidate),
+            GetMethods(existing),
+            candidate.RoutePattern.RawText ?? string.Empty,
+            existing.RoutePattern.RawText ?? string.Empty);
+    }
+
+    private static string DescribeOwner(Endpoint endpoint)
+    {
+        var ownership = endpoint.Metadata.GetMetadata<EndpointOwnershipMetadata>();
+        if (ownership is not null)
+            return $"{ownership.OwnerKind}:{ownership.OwnerId}";
+
+        var shell = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+        if (shell is not null)
+            return $"{shell.OwnerKind}:{shell.OwnerId}";
+
+        return $"Host:{endpoint.DisplayName ?? "(unnamed endpoint)"}";
+    }
+
+    private static bool IsHostEndpoint(Endpoint endpoint) =>
+        endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null;
 
     private void NotifyChanged()
     {

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -391,10 +391,19 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                 var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
                 return metadata is null || !metadata.ShellId.Equals(shellId);
             });
-            Volatile.Write(ref _publishedEndpoints, [.. retained, .. retired]);
+            var restorable = retired.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !pending.DeferredGenerationRemovals.Contains(metadata.Generation);
+            });
+
+            // A generation may finish draining while the replacement transaction is pending.
+            // Fold that deferred cleanup into the rollback snapshot before publication: observers
+            // receive one notification for the final state and can never transiently match a
+            // disposed generation between restore and a second removal notification.
+            Volatile.Write(ref _publishedEndpoints, [.. retained, .. restorable]);
             AdvanceVersion(shellId);
             NotifyChanged();
-            ApplyDeferredGenerationRemovals(pending);
             _pendingTransaction = null;
         }
     }

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -17,6 +17,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     private IReadOnlyList<Endpoint> _hostEndpoints = [];
     private readonly object _publicationLock = new();
     private readonly Dictionary<ShellId, long> _shellVersions = [];
+    // Route collision validity is global: a rollback can restore routes that overlap a newer
+    // shell or host mutation. Keep exactly one rollback-capable commit until its owner finalizes.
+    private PendingTransaction? _pendingTransaction;
+    private long _nextTransactionId;
     private CancellationTokenSource _cts = new();
     private readonly ILogger<DynamicShellEndpointDataSource> _logger = logger ?? NullLogger<DynamicShellEndpointDataSource>.Instance;
 
@@ -42,6 +46,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
 
         lock (_publicationLock)
         {
+            EnsureNoPendingTransaction("add endpoints");
+
             ValidateCandidate(additions, existingShellId: null, allowSameShellGenerations: true);
             var published = Volatile.Read(ref _publishedEndpoints);
             Volatile.Write(ref _publishedEndpoints, [.. published, .. additions]);
@@ -71,8 +77,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     /// <summary>
-    /// Prepares an endpoint generation without changing the routing-visible snapshot. Commit
-    /// revalidates and performs the complete replacement under the publication lock.
+    /// Prepares an endpoint generation without changing the routing-visible snapshot. Preparation
+    /// may overlap; commit revalidates under the publication lock and is rejected while another
+    /// rollback-capable commit owns the global route inventory.
     /// </summary>
     internal ShellEndpointGenerationPublication PrepareGeneration(
         ShellId shellId,
@@ -87,7 +94,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         lock (_publicationLock)
         {
             if (candidateHostEndpoints is not null)
+            {
+                EnsureNoPendingTransaction("replace the host endpoint inventory");
                 _hostEndpoints = candidateHostEndpoints;
+            }
 
             ValidateGenerationIdentity(shellId, generation, candidate);
             ValidateCandidate(
@@ -99,6 +109,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
 
         return new ShellEndpointGenerationPublication(
             this,
+            Interlocked.Increment(ref _nextTransactionId),
             shellId,
             generation,
             candidate);
@@ -108,7 +119,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     internal void RetireGeneration(ShellId shellId, int generation)
     {
         lock (_publicationLock)
+        {
+            EnsureNoPendingTransaction("retire a generation");
             RemoveGeneration(shellId, generation, Volatile.Read(ref _publishedEndpoints));
+        }
     }
 
     /// <summary>
@@ -120,7 +134,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         Guard.Against.Null(endpoints);
         lock (_publicationLock)
+        {
+            EnsureNoPendingTransaction("replace the host endpoint inventory");
             _hostEndpoints = endpoints.Where(IsHostEndpoint).ToArray();
+        }
     }
 
     /// <summary>
@@ -130,6 +147,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            EnsureNoPendingTransaction("remove endpoints");
             var published = Volatile.Read(ref _publishedEndpoints);
             var retained = published.Where(endpoint =>
             {
@@ -152,6 +170,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            EnsureNoPendingTransaction("remove a generation");
             var published = Volatile.Read(ref _publishedEndpoints);
             RemoveGeneration(shellId, generation, published);
         }
@@ -164,6 +183,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
+            EnsureNoPendingTransaction("clear endpoints");
+
             var published = Volatile.Read(ref _publishedEndpoints);
             if (published.Count == 0)
                 return;
@@ -307,12 +328,15 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null;
 
     private CommittedGeneration CommitGeneration(
+        long transactionId,
         ShellId shellId,
         int generation,
         IReadOnlyList<Endpoint> candidate)
     {
         lock (_publicationLock)
         {
+            EnsureNoPendingTransaction("commit another generation");
+
             // Preparation can be arbitrarily delayed. Revalidate against the latest endpoint
             // inventory at commit so concurrent publications are serialized deterministically.
             ValidateGenerationIdentity(shellId, generation, candidate);
@@ -330,6 +354,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                 return metadata is null || !metadata.ShellId.Equals(shellId);
             });
 
+            _pendingTransaction = new PendingTransaction(transactionId, shellId);
             Volatile.Write(ref _publishedEndpoints, [.. retained, .. candidate]);
             var version = AdvanceVersion(shellId);
             NotifyChanged();
@@ -338,14 +363,23 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     private void RollbackGeneration(
+        long transactionId,
         ShellId shellId,
         long committedVersion,
         IReadOnlyList<Endpoint> retired)
     {
         lock (_publicationLock)
         {
-            if (GetVersion(shellId) != committedVersion)
+            if (_pendingTransaction is not { } pending
+                || pending.TransactionId != transactionId
+                || !pending.ShellId.Equals(shellId))
                 return;
+
+            if (GetVersion(shellId) != committedVersion)
+            {
+                throw new InvalidOperationException(
+                    $"Shell endpoint publication transaction {transactionId} for '{shellId}' lost ownership of its committed snapshot.");
+            }
 
             var published = Volatile.Read(ref _publishedEndpoints);
             var retained = published.Where(endpoint =>
@@ -355,7 +389,34 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             });
             Volatile.Write(ref _publishedEndpoints, [.. retained, .. retired]);
             AdvanceVersion(shellId);
+            _pendingTransaction = null;
             NotifyChanged();
+        }
+    }
+
+    private void CompleteGeneration(long transactionId, ShellId shellId)
+    {
+        lock (_publicationLock)
+        {
+            if (_pendingTransaction is not { } pending
+                || pending.TransactionId != transactionId
+                || !pending.ShellId.Equals(shellId))
+            {
+                throw new InvalidOperationException(
+                    $"Shell endpoint publication transaction {transactionId} for '{shellId}' is not the pending committed transaction.");
+            }
+
+            _pendingTransaction = null;
+        }
+    }
+
+    private void EnsureNoPendingTransaction(string operation)
+    {
+        if (_pendingTransaction is { } pending)
+        {
+            throw new InvalidOperationException(
+                $"Cannot {operation} while endpoint publication transaction {pending.TransactionId} " +
+                $"for shell '{pending.ShellId}' is awaiting completion or rollback.");
         }
     }
 
@@ -411,6 +472,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     internal sealed class ShellEndpointGenerationPublication : IDisposable
     {
         private readonly DynamicShellEndpointDataSource owner;
+        private readonly long transactionId;
         private readonly ShellId shellId;
         private readonly int generation;
         private readonly object gate = new();
@@ -421,11 +483,13 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
 
         internal ShellEndpointGenerationPublication(
             DynamicShellEndpointDataSource owner,
+            long transactionId,
             ShellId shellId,
             int generation,
             IReadOnlyList<Endpoint> candidate)
         {
             this.owner = owner;
+            this.transactionId = transactionId;
             this.shellId = shellId;
             this.generation = generation;
             this.candidate = candidate;
@@ -438,7 +502,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                 if (state != PublicationState.Prepared)
                     throw new InvalidOperationException($"Endpoint generation publication is already {state}.");
 
-                var committed = owner.CommitGeneration(shellId, generation, candidate);
+                var committed = owner.CommitGeneration(transactionId, shellId, generation, candidate);
                 retired = committed.Retired;
                 committedVersion = committed.Version;
                 state = PublicationState.Committed;
@@ -453,6 +517,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                 if (state != PublicationState.Committed)
                     throw new InvalidOperationException($"Endpoint generation publication is already {state}.");
 
+                owner.CompleteGeneration(transactionId, shellId);
                 state = PublicationState.Completed;
                 ReleaseRollback();
             }
@@ -472,7 +537,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                 if (state != PublicationState.Committed)
                     return;
 
-                owner.RollbackGeneration(shellId, committedVersion, retired);
+                owner.RollbackGeneration(transactionId, shellId, committedVersion, retired);
                 state = PublicationState.RolledBack;
                 ReleaseRollback();
             }
@@ -510,4 +575,5 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     private sealed record CommittedGeneration(long Version, IReadOnlyList<Endpoint> Retired);
+    private sealed record PendingTransaction(long TransactionId, ShellId ShellId);
 }

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -120,7 +120,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            EnsureNoPendingTransaction("retire a generation");
+            if (DeferPendingGenerationRemoval(shellId, generation))
+                return;
+
             RemoveGeneration(shellId, generation, Volatile.Read(ref _publishedEndpoints));
         }
     }
@@ -147,7 +149,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            EnsureNoPendingTransaction("remove endpoints");
+            EnsurePendingTransactionDoesNotOwn(shellId, "remove every generation");
             var published = Volatile.Read(ref _publishedEndpoints);
             var retained = published.Where(endpoint =>
             {
@@ -170,7 +172,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            EnsureNoPendingTransaction("remove a generation");
+            if (DeferPendingGenerationRemoval(shellId, generation))
+                return;
+
             var published = Volatile.Read(ref _publishedEndpoints);
             RemoveGeneration(shellId, generation, published);
         }
@@ -389,8 +393,9 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             });
             Volatile.Write(ref _publishedEndpoints, [.. retained, .. retired]);
             AdvanceVersion(shellId);
-            _pendingTransaction = null;
             NotifyChanged();
+            ApplyDeferredGenerationRemovals(pending);
+            _pendingTransaction = null;
         }
     }
 
@@ -406,7 +411,33 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
                     $"Shell endpoint publication transaction {transactionId} for '{shellId}' is not the pending committed transaction.");
             }
 
+            ApplyDeferredGenerationRemovals(pending);
             _pendingTransaction = null;
+        }
+    }
+
+    private bool DeferPendingGenerationRemoval(ShellId shellId, int generation)
+    {
+        if (_pendingTransaction is not { } pending || !pending.ShellId.Equals(shellId))
+            return false;
+
+        pending.DeferredGenerationRemovals.Add(generation);
+        return true;
+    }
+
+    private void ApplyDeferredGenerationRemovals(PendingTransaction pending)
+    {
+        foreach (var generation in pending.DeferredGenerationRemovals)
+            RemoveGeneration(pending.ShellId, generation, Volatile.Read(ref _publishedEndpoints));
+    }
+
+    private void EnsurePendingTransactionDoesNotOwn(ShellId shellId, string operation)
+    {
+        if (_pendingTransaction is { } pending && pending.ShellId.Equals(shellId))
+        {
+            throw new InvalidOperationException(
+                $"Cannot {operation} for shell '{shellId}' while endpoint publication transaction " +
+                $"{pending.TransactionId} owns its rollback snapshot.");
         }
     }
 
@@ -575,5 +606,10 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     private sealed record CommittedGeneration(long Version, IReadOnlyList<Endpoint> Retired);
-    private sealed record PendingTransaction(long TransactionId, ShellId ShellId);
+    private sealed class PendingTransaction(long transactionId, ShellId shellId)
+    {
+        internal long TransactionId { get; } = transactionId;
+        internal ShellId ShellId { get; } = shellId;
+        internal HashSet<int> DeferredGenerationRemovals { get; } = [];
+    }
 }

--- a/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
+++ b/src/CShells.AspNetCore/Routing/DynamicShellEndpointDataSource.cs
@@ -15,8 +15,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
 {
     private IReadOnlyList<Endpoint> _publishedEndpoints = [];
     private IReadOnlyList<Endpoint> _hostEndpoints = [];
-    private readonly Dictionary<ShellId, PendingGenerationReplacement> _pendingReplacements = [];
     private readonly object _publicationLock = new();
+    private readonly Dictionary<ShellId, long> _shellVersions = [];
     private CancellationTokenSource _cts = new();
     private readonly ILogger<DynamicShellEndpointDataSource> _logger = logger ?? NullLogger<DynamicShellEndpointDataSource>.Instance;
 
@@ -27,7 +27,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     }
 
     /// <inheritdoc />
-    public override IChangeToken GetChangeToken() => new CancellationChangeToken(_cts.Token);
+    public override IChangeToken GetChangeToken() =>
+        new CancellationChangeToken(Volatile.Read(ref _cts).Token);
 
     /// <summary>
     /// Adds endpoints for a shell.
@@ -43,7 +44,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         {
             ValidateCandidate(additions, existingShellId: null, allowSameShellGenerations: true);
             var published = Volatile.Read(ref _publishedEndpoints);
-            Volatile.Write(ref _publishedEndpoints, [..published, ..additions]);
+            Volatile.Write(ref _publishedEndpoints, [.. published, .. additions]);
+            AdvanceVersions(additions);
             NotifyChanged();
         }
     }
@@ -63,76 +65,50 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
         IEnumerable<Endpoint> endpoints,
         IEnumerable<Endpoint>? hostEndpoints = null)
     {
-        Guard.Against.Null(endpoints);
-        var candidate = endpoints.ToArray();
-
-        lock (_publicationLock)
-        {
-            if (hostEndpoints is not null)
-                _hostEndpoints = hostEndpoints.Where(IsHostEndpoint).ToArray();
-
-            ValidateGenerationIdentity(shellId, generation, candidate);
-            ValidateCandidate(candidate, shellId, allowSameShellGenerations: false);
-
-            var published = Volatile.Read(ref _publishedEndpoints);
-            var retired = published.Where(endpoint =>
-            {
-                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-                return metadata is not null && metadata.ShellId.Equals(shellId);
-            }).ToArray();
-            var retained = published.Where(endpoint =>
-            {
-                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-                return metadata is null || !metadata.ShellId.Equals(shellId);
-            });
-
-            _pendingReplacements[shellId] = new PendingGenerationReplacement(generation, retired);
-            Volatile.Write(ref _publishedEndpoints, [..retained, ..candidate]);
-            NotifyChanged();
-        }
+        using var publication = PrepareGeneration(shellId, generation, endpoints, hostEndpoints);
+        publication.Commit();
+        publication.Complete();
     }
 
     /// <summary>
-    /// Retires a generation during normal deactivation. This commits any pending replacement
-    /// transaction involving that generation and removes its published endpoints.
+    /// Prepares an endpoint generation without changing the routing-visible snapshot. Commit
+    /// revalidates and performs the complete replacement under the publication lock.
     /// </summary>
+    internal ShellEndpointGenerationPublication PrepareGeneration(
+        ShellId shellId,
+        int generation,
+        IEnumerable<Endpoint> endpoints,
+        IEnumerable<Endpoint>? hostEndpoints = null)
+    {
+        Guard.Against.Null(endpoints);
+        var candidate = endpoints.ToArray();
+        var candidateHostEndpoints = hostEndpoints?.Where(IsHostEndpoint).ToArray();
+
+        lock (_publicationLock)
+        {
+            if (candidateHostEndpoints is not null)
+                _hostEndpoints = candidateHostEndpoints;
+
+            ValidateGenerationIdentity(shellId, generation, candidate);
+            ValidateCandidate(
+                candidate,
+                shellId,
+                allowSameShellGenerations: false,
+                Volatile.Read(ref _hostEndpoints));
+        }
+
+        return new ShellEndpointGenerationPublication(
+            this,
+            shellId,
+            generation,
+            candidate);
+    }
+
+    /// <summary>Retires a generation during normal deactivation.</summary>
     internal void RetireGeneration(ShellId shellId, int generation)
     {
         lock (_publicationLock)
-        {
-            CommitPendingReplacement(shellId, generation);
             RemoveGeneration(shellId, generation, Volatile.Read(ref _publishedEndpoints));
-        }
-    }
-
-    /// <summary>
-    /// Rejects a candidate generation. When the generation still owns a pending replacement,
-    /// its retired endpoint snapshot is restored atomically; otherwise only that generation is removed.
-    /// </summary>
-    internal void RollbackGeneration(ShellId shellId, int generation)
-    {
-        lock (_publicationLock)
-        {
-            var published = Volatile.Read(ref _publishedEndpoints);
-            if (_pendingReplacements.TryGetValue(shellId, out var pending) && pending.CandidateGeneration == generation)
-            {
-                var retained = published.Where(endpoint =>
-                {
-                    var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
-                    return metadata is null || !metadata.ShellId.Equals(shellId);
-                });
-                var changed = pending.RetiredEndpoints.Count > 0 || published.Any(endpoint =>
-                    endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) == true);
-
-                _pendingReplacements.Remove(shellId);
-                Volatile.Write(ref _publishedEndpoints, [..retained, ..pending.RetiredEndpoints]);
-                if (changed)
-                    NotifyChanged();
-                return;
-            }
-
-            RemoveGeneration(shellId, generation, published);
-        }
     }
 
     /// <summary>
@@ -154,7 +130,6 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            _pendingReplacements.Remove(shellId);
             var published = Volatile.Read(ref _publishedEndpoints);
             var retained = published.Where(endpoint =>
             {
@@ -164,6 +139,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             if (retained.Length != published.Count)
             {
                 Volatile.Write(ref _publishedEndpoints, retained);
+                AdvanceVersion(shellId);
                 NotifyChanged();
             }
         }
@@ -176,7 +152,6 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            CommitPendingReplacement(shellId, generation);
             var published = Volatile.Read(ref _publishedEndpoints);
             RemoveGeneration(shellId, generation, published);
         }
@@ -189,12 +164,12 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     {
         lock (_publicationLock)
         {
-            _pendingReplacements.Clear();
             var published = Volatile.Read(ref _publishedEndpoints);
             if (published.Count == 0)
                 return;
 
             Volatile.Write(ref _publishedEndpoints, []);
+            AdvanceVersions(published);
             NotifyChanged();
         }
     }
@@ -202,7 +177,8 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     private void ValidateCandidate(
         IReadOnlyList<Endpoint> candidate,
         ShellId? existingShellId,
-        bool allowSameShellGenerations)
+        bool allowSameShellGenerations,
+        IReadOnlyList<Endpoint>? hostEndpoints = null)
     {
         var published = Volatile.Read(ref _publishedEndpoints);
         var candidateShellIds = candidate
@@ -215,7 +191,7 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             .GroupBy(metadata => metadata!.ShellId)
             .ToDictionary(group => group.Key, group => group.Select(metadata => metadata!.Generation).ToHashSet());
         var existing = published
-            .Concat(Volatile.Read(ref _hostEndpoints))
+            .Concat(hostEndpoints ?? Volatile.Read(ref _hostEndpoints))
             .Where(endpoint =>
             {
                 if (existingShellId is null && allowSameShellGenerations)
@@ -330,15 +306,57 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
     private static bool IsHostEndpoint(Endpoint endpoint) =>
         endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is null;
 
-    private void CommitPendingReplacement(ShellId shellId, int generation)
+    private CommittedGeneration CommitGeneration(
+        ShellId shellId,
+        int generation,
+        IReadOnlyList<Endpoint> candidate)
     {
-        if (!_pendingReplacements.TryGetValue(shellId, out var pending))
-            return;
+        lock (_publicationLock)
+        {
+            // Preparation can be arbitrarily delayed. Revalidate against the latest endpoint
+            // inventory at commit so concurrent publications are serialized deterministically.
+            ValidateGenerationIdentity(shellId, generation, candidate);
+            ValidateCandidate(candidate, shellId, allowSameShellGenerations: false);
 
-        var retiresGeneration = pending.RetiredEndpoints.Any(endpoint =>
-            endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.Generation == generation);
-        if (pending.CandidateGeneration == generation || retiresGeneration)
-            _pendingReplacements.Remove(shellId);
+            var published = Volatile.Read(ref _publishedEndpoints);
+            var retired = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is not null && metadata.ShellId.Equals(shellId);
+            }).ToArray();
+            var retained = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(shellId);
+            });
+
+            Volatile.Write(ref _publishedEndpoints, [.. retained, .. candidate]);
+            var version = AdvanceVersion(shellId);
+            NotifyChanged();
+            return new CommittedGeneration(version, retired);
+        }
+    }
+
+    private void RollbackGeneration(
+        ShellId shellId,
+        long committedVersion,
+        IReadOnlyList<Endpoint> retired)
+    {
+        lock (_publicationLock)
+        {
+            if (GetVersion(shellId) != committedVersion)
+                return;
+
+            var published = Volatile.Read(ref _publishedEndpoints);
+            var retained = published.Where(endpoint =>
+            {
+                var metadata = endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+                return metadata is null || !metadata.ShellId.Equals(shellId);
+            });
+            Volatile.Write(ref _publishedEndpoints, [.. retained, .. retired]);
+            AdvanceVersion(shellId);
+            NotifyChanged();
+        }
     }
 
     private void RemoveGeneration(ShellId shellId, int generation, IReadOnlyList<Endpoint> published)
@@ -352,18 +370,144 @@ public class DynamicShellEndpointDataSource(ILogger<DynamicShellEndpointDataSour
             return;
 
         Volatile.Write(ref _publishedEndpoints, retained);
+        AdvanceVersion(shellId);
         NotifyChanged();
     }
 
-    private void NotifyChanged()
+    private long AdvanceVersion(ShellId shellId)
     {
-        var oldCts = _cts;
-        _cts = new();
-        oldCts.Cancel();
-        oldCts.Dispose();
+        var version = GetVersion(shellId) + 1;
+        _shellVersions[shellId] = version;
+        return version;
     }
 
-    private sealed record PendingGenerationReplacement(
-        int CandidateGeneration,
-        IReadOnlyList<Endpoint> RetiredEndpoints);
+    private void AdvanceVersions(IEnumerable<Endpoint> endpoints)
+    {
+        foreach (var shellId in endpoints
+                     .Select(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId)
+                     .OfType<ShellId>()
+                     .Distinct())
+            AdvanceVersion(shellId);
+    }
+
+    private long GetVersion(ShellId shellId) =>
+        _shellVersions.GetValueOrDefault(shellId);
+
+    private void NotifyChanged()
+    {
+        var previous = Interlocked.Exchange(ref _cts, new CancellationTokenSource());
+        try
+        {
+            previous.Cancel();
+        }
+        catch (AggregateException ex)
+        {
+            // Change observers must not be able to turn an already-visible atomic publication
+            // into a failed commit. Routing will observe the new snapshot on its next read.
+            _logger.LogError(ex, "An endpoint change observer threw while processing publication.");
+        }
+    }
+
+    internal sealed class ShellEndpointGenerationPublication : IDisposable
+    {
+        private readonly DynamicShellEndpointDataSource owner;
+        private readonly ShellId shellId;
+        private readonly int generation;
+        private readonly object gate = new();
+        private IReadOnlyList<Endpoint> candidate;
+        private IReadOnlyList<Endpoint> retired = [];
+        private long committedVersion;
+        private PublicationState state;
+
+        internal ShellEndpointGenerationPublication(
+            DynamicShellEndpointDataSource owner,
+            ShellId shellId,
+            int generation,
+            IReadOnlyList<Endpoint> candidate)
+        {
+            this.owner = owner;
+            this.shellId = shellId;
+            this.generation = generation;
+            this.candidate = candidate;
+        }
+
+        internal void Commit()
+        {
+            lock (gate)
+            {
+                if (state != PublicationState.Prepared)
+                    throw new InvalidOperationException($"Endpoint generation publication is already {state}.");
+
+                var committed = owner.CommitGeneration(shellId, generation, candidate);
+                retired = committed.Retired;
+                committedVersion = committed.Version;
+                state = PublicationState.Committed;
+                ReleaseCandidate();
+            }
+        }
+
+        internal void Complete()
+        {
+            lock (gate)
+            {
+                if (state != PublicationState.Committed)
+                    throw new InvalidOperationException($"Endpoint generation publication is already {state}.");
+
+                state = PublicationState.Completed;
+                ReleaseRollback();
+            }
+        }
+
+        internal void Rollback()
+        {
+            lock (gate)
+            {
+                if (state == PublicationState.Prepared)
+                {
+                    state = PublicationState.RolledBack;
+                    ReleaseCandidate();
+                    return;
+                }
+
+                if (state != PublicationState.Committed)
+                    return;
+
+                owner.RollbackGeneration(shellId, committedVersion, retired);
+                state = PublicationState.RolledBack;
+                ReleaseRollback();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (gate)
+            {
+                if (state == PublicationState.Prepared)
+                    Rollback();
+                else if (state == PublicationState.Committed)
+                    Complete();
+            }
+        }
+
+        private void ReleaseCandidate()
+        {
+            candidate = [];
+        }
+
+        private void ReleaseRollback()
+        {
+            retired = [];
+            committedVersion = 0;
+        }
+
+        private enum PublicationState
+        {
+            Prepared,
+            Committed,
+            Completed,
+            RolledBack,
+        }
+    }
+
+    private sealed record CommittedGeneration(long Version, IReadOnlyList<Endpoint> Retired);
 }

--- a/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
@@ -97,12 +97,8 @@ internal sealed class ShellEndpointGenerationLease(
             return false;
         }
 
-        IShellScope scope;
-        try
-        {
-            scope = shell.BeginScope();
-        }
-        catch (InvalidOperationException)
+        var scope = TryBeginScope(shell);
+        if (scope is null)
         {
             lease = null;
             return false;
@@ -123,6 +119,18 @@ internal sealed class ShellEndpointGenerationLease(
             acquired.DisposeAsync().AsTask().GetAwaiter().GetResult();
             lease = null;
             throw;
+        }
+    }
+
+    private static IShellScope? TryBeginScope(IShell shell)
+    {
+        try
+        {
+            return shell.BeginScope();
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
         }
     }
 

--- a/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
@@ -1,0 +1,94 @@
+using CShells.Lifecycle;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+
+namespace CShells.AspNetCore.Routing;
+
+/// <summary>
+/// Acquires the exact shell-generation scope while endpoint matching still owns the selected
+/// generation. This closes the handoff gap between routing and shell middleware during reload.
+/// </summary>
+internal sealed class ShellEndpointGenerationMatcherPolicy(IShellRegistry registry) :
+    MatcherPolicy,
+    IEndpointSelectorPolicy
+{
+    private readonly IShellRegistry registry = Guard.Against.Null(registry);
+
+    // Run after framework method, host, and constraint policies have invalidated candidates.
+    public override int Order => int.MaxValue;
+
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints) =>
+        endpoints.Any(endpoint => endpoint.Metadata.GetMetadata<ShellEndpointMetadata>() is not null);
+
+    public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+    {
+        Guard.Against.Null(httpContext);
+        Guard.Against.Null(candidates);
+
+        // Matcher policy execution may be re-entered. One request owns at most one generation
+        // lease, registered for release at response completion when it is first acquired.
+        if (httpContext.Features.Get<ShellEndpointGenerationLease>() is not null)
+            return Task.CompletedTask;
+
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            if (!candidates.IsValidCandidate(i))
+                continue;
+
+            var metadata = candidates[i].Endpoint.Metadata.GetMetadata<ShellEndpointMetadata>();
+            if (metadata is null)
+                continue;
+
+            var shell = registry.GetAll(metadata.ShellId.Name)
+                .FirstOrDefault(candidate => candidate.Descriptor.Generation == metadata.Generation);
+            if (shell is null)
+            {
+                candidates.SetValidity(i, false);
+                continue;
+            }
+
+            try
+            {
+                var lease = new ShellEndpointGenerationLease(metadata.ShellId, metadata.Generation, shell.BeginScope());
+                httpContext.Features.Set(lease);
+                httpContext.Response.OnCompleted(
+                    static state => ((ShellEndpointGenerationLease)state).DisposeAsync().AsTask(),
+                    lease);
+                return Task.CompletedTask;
+            }
+            catch (InvalidOperationException)
+            {
+                // Drain disposal won the race before this candidate became a successful match.
+                candidates.SetValidity(i, false);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Request-local exact-generation scope acquired by endpoint matching.</summary>
+internal sealed class ShellEndpointGenerationLease(
+    ShellId shellId,
+    int generation,
+    IShellScope scope) : IAsyncDisposable
+{
+    private readonly IShellScope scope = Guard.Against.Null(scope);
+    private int disposed;
+
+    internal ShellId ShellId { get; } = shellId;
+    internal int Generation { get; } = generation;
+    internal IShellScope Scope => scope;
+
+    internal bool Matches(ShellEndpointMetadata metadata) =>
+        ShellId.Equals(metadata.ShellId) && Generation == metadata.Generation;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+
+        await scope.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointGenerationMatcherPolicy.cs
@@ -48,20 +48,13 @@ internal sealed class ShellEndpointGenerationMatcherPolicy(IShellRegistry regist
                 continue;
             }
 
-            try
+            if (ShellEndpointGenerationLease.TryAcquire(httpContext, metadata, shell, out _))
             {
-                var lease = new ShellEndpointGenerationLease(metadata.ShellId, metadata.Generation, shell.BeginScope());
-                httpContext.Features.Set(lease);
-                httpContext.Response.OnCompleted(
-                    static state => ((ShellEndpointGenerationLease)state).DisposeAsync().AsTask(),
-                    lease);
                 return Task.CompletedTask;
             }
-            catch (InvalidOperationException)
-            {
-                // Drain disposal won the race before this candidate became a successful match.
-                candidates.SetValidity(i, false);
-            }
+
+            // Drain disposal won the race before this candidate became a successful match.
+            candidates.SetValidity(i, false);
         }
 
         return Task.CompletedTask;
@@ -83,6 +76,55 @@ internal sealed class ShellEndpointGenerationLease(
 
     internal bool Matches(ShellEndpointMetadata metadata) =>
         ShellId.Equals(metadata.ShellId) && Generation == metadata.Generation;
+
+    internal static bool TryAcquire(
+        HttpContext context,
+        ShellEndpointMetadata metadata,
+        IShell shell,
+        out ShellEndpointGenerationLease? lease)
+    {
+        var existing = context.Features.Get<ShellEndpointGenerationLease>();
+        if (existing is not null)
+        {
+            lease = existing.Matches(metadata) ? existing : null;
+            return lease is not null;
+        }
+
+        if (!string.Equals(shell.Descriptor.Name, metadata.ShellId.Name, StringComparison.OrdinalIgnoreCase)
+            || shell.Descriptor.Generation != metadata.Generation)
+        {
+            lease = null;
+            return false;
+        }
+
+        IShellScope scope;
+        try
+        {
+            scope = shell.BeginScope();
+        }
+        catch (InvalidOperationException)
+        {
+            lease = null;
+            return false;
+        }
+
+        var acquired = new ShellEndpointGenerationLease(metadata.ShellId, metadata.Generation, scope);
+        try
+        {
+            context.Response.OnCompleted(
+                static state => ((ShellEndpointGenerationLease)state).DisposeAsync().AsTask(),
+                acquired);
+            context.Features.Set(acquired);
+            lease = acquired;
+            return true;
+        }
+        catch
+        {
+            acquired.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            lease = null;
+            throw;
+        }
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
@@ -51,15 +51,15 @@ public record ShellEndpointMetadata(
 /// <summary>
 /// Describes a deterministic conflict between two route endpoints.
 /// </summary>
-/// <param name="CandidateOwner">The owner of the unpublished candidate endpoint.</param>
-/// <param name="ExistingOwner">The owner of the already published endpoint.</param>
+/// <param name="CandidateOwner">Structured ownership of the unpublished candidate endpoint.</param>
+/// <param name="ExistingOwner">Structured ownership of the already published endpoint.</param>
 /// <param name="CandidateMethods">Methods accepted by the candidate endpoint.</param>
 /// <param name="ExistingMethods">Methods accepted by the existing endpoint.</param>
 /// <param name="CandidatePattern">The candidate route template.</param>
 /// <param name="ExistingPattern">The existing route template.</param>
 public sealed record ShellEndpointConflict(
-    string CandidateOwner,
-    string ExistingOwner,
+    EndpointOwnershipMetadata CandidateOwner,
+    EndpointOwnershipMetadata ExistingOwner,
     IReadOnlyList<string> CandidateMethods,
     IReadOnlyList<string> ExistingMethods,
     string CandidatePattern,
@@ -82,8 +82,16 @@ public sealed class ShellEndpointConflictException : InvalidOperationException
     public ShellEndpointConflict Conflict { get; }
 
     private static string CreateMessage(ShellEndpointConflict conflict) =>
-        $"Endpoint route conflict: candidate owner '{conflict.CandidateOwner}' " +
+        $"Endpoint route conflict: candidate owner '{FormatOwner(conflict.CandidateOwner)}' " +
         $"({string.Join(", ", conflict.CandidateMethods)} {conflict.CandidatePattern}) " +
-        $"conflicts with existing owner '{conflict.ExistingOwner}' " +
+        $"conflicts with existing owner '{FormatOwner(conflict.ExistingOwner)}' " +
         $"({string.Join(", ", conflict.ExistingMethods)} {conflict.ExistingPattern}).";
+
+    private static string FormatOwner(EndpointOwnershipMetadata owner)
+    {
+        var description = $"{owner.OwnerKind}:{owner.OwnerId}";
+        return owner.ShellId is { } shellId && owner.Generation is { } generation
+            ? $"{description}, shell '{shellId}' generation {generation}"
+            : description;
+    }
 }

--- a/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
@@ -72,6 +72,7 @@ public sealed record ShellEndpointConflict(
 public sealed class ShellEndpointConflictException : InvalidOperationException
 {
     /// <summary>Initializes a new exception with structured conflict details.</summary>
+    /// <param name="conflict">The structured candidate and existing endpoint conflict.</param>
     public ShellEndpointConflictException(ShellEndpointConflict conflict)
         : base(CreateMessage(Guard.Against.Null(conflict)))
     {

--- a/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointMetadata.cs
@@ -1,9 +1,89 @@
 namespace CShells.AspNetCore.Routing;
 
 /// <summary>
+/// Identifies the conceptual owner of an ASP.NET Core endpoint.
+/// </summary>
+public enum EndpointOwnerKind
+{
+    /// <summary>The host application owns the endpoint.</summary>
+    Host,
+
+    /// <summary>A statically composed module owns the endpoint.</summary>
+    Module,
+
+    /// <summary>A dynamically loaded shell feature owns the endpoint.</summary>
+    DynamicShell,
+}
+
+/// <summary>
+/// Typed route ownership metadata used by endpoint inventory and collision diagnostics.
+/// </summary>
+/// <param name="OwnerKind">The conceptual owner category.</param>
+/// <param name="OwnerId">The stable owner identifier.</param>
+/// <param name="ShellId">The shell identifier for dynamic-shell endpoints.</param>
+/// <param name="Generation">The shell generation for dynamic-shell endpoints.</param>
+public sealed record EndpointOwnershipMetadata(
+    EndpointOwnerKind OwnerKind,
+    string OwnerId,
+    ShellId? ShellId = null,
+    int? Generation = null);
+
+/// <summary>
 /// Metadata attached to endpoints to identify which shell they belong to.
 /// </summary>
 /// <param name="ShellId">The ID of the shell that owns this endpoint.</param>
 /// <param name="Generation">The shell generation that registered this endpoint.</param>
 /// <param name="ShellSettings">The shell settings for this endpoint.</param>
-public record ShellEndpointMetadata(ShellId ShellId, int Generation, ShellSettings ShellSettings);
+/// <param name="FeatureName">The feature that mapped the endpoint, when known.</param>
+public record ShellEndpointMetadata(
+    ShellId ShellId,
+    int Generation,
+    ShellSettings ShellSettings,
+    string? FeatureName = null)
+{
+    /// <summary>Gets the conceptual owner kind for this endpoint.</summary>
+    public EndpointOwnerKind OwnerKind => EndpointOwnerKind.DynamicShell;
+
+    /// <summary>Gets the stable feature or shell owner identifier.</summary>
+    public string OwnerId => string.IsNullOrWhiteSpace(FeatureName) ? ShellId.Name : FeatureName;
+}
+
+/// <summary>
+/// Describes a deterministic conflict between two route endpoints.
+/// </summary>
+/// <param name="CandidateOwner">The owner of the unpublished candidate endpoint.</param>
+/// <param name="ExistingOwner">The owner of the already published endpoint.</param>
+/// <param name="CandidateMethods">Methods accepted by the candidate endpoint.</param>
+/// <param name="ExistingMethods">Methods accepted by the existing endpoint.</param>
+/// <param name="CandidatePattern">The candidate route template.</param>
+/// <param name="ExistingPattern">The existing route template.</param>
+public sealed record ShellEndpointConflict(
+    string CandidateOwner,
+    string ExistingOwner,
+    IReadOnlyList<string> CandidateMethods,
+    IReadOnlyList<string> ExistingMethods,
+    string CandidatePattern,
+    string ExistingPattern);
+
+/// <summary>
+/// Thrown when an endpoint generation contains a route collision with an existing route or
+/// another endpoint in the same candidate batch.
+/// </summary>
+public sealed class ShellEndpointConflictException : InvalidOperationException
+{
+    /// <summary>Initializes a new exception with structured conflict details.</summary>
+    public ShellEndpointConflictException(ShellEndpointConflict conflict)
+        : base(CreateMessage(Guard.Against.Null(conflict)))
+    {
+        Conflict = conflict;
+    }
+
+    /// <summary>Gets the structured route conflict details.</summary>
+    public ShellEndpointConflict Conflict { get; }
+
+    private static string CreateMessage(ShellEndpointConflict conflict) =>
+        $"Endpoint route conflict: candidate owner '{conflict.CandidateOwner}' " +
+        $"({string.Join(", ", conflict.CandidateMethods)} {conflict.CandidatePattern}) " +
+        $"conflicts with existing owner '{conflict.ExistingOwner}' " +
+        $"({string.Join(", ", conflict.ExistingMethods)} {conflict.ExistingPattern}).";
+}

--- a/src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs
+++ b/src/CShells.AspNetCore/Routing/ShellEndpointRouteBuilder.cs
@@ -19,6 +19,7 @@ public class ShellEndpointRouteBuilder(
     : IEndpointRouteBuilder
 {
     private readonly List<EndpointDataSource> _dataSources = [];
+    private readonly Dictionary<Endpoint, string> _featureOwners = [];
 
     /// <inheritdoc />
     public IServiceProvider ServiceProvider { get; } = shellContextServiceProvider;
@@ -46,6 +47,20 @@ public class ShellEndpointRouteBuilder(
         }
     }
 
+    /// <summary>Gets the raw endpoint objects currently contributed by feature data sources.</summary>
+    internal IReadOnlyList<Endpoint> GetRawEndpoints() =>
+        [.._dataSources.SelectMany(dataSource => dataSource.Endpoints)];
+
+    /// <summary>Associates newly mapped endpoints with their owning feature.</summary>
+    internal void AssignFeature(string featureName, IEnumerable<Endpoint> endpoints)
+    {
+        Guard.Against.NullOrWhiteSpace(featureName);
+        Guard.Against.Null(endpoints);
+
+        foreach (var endpoint in endpoints)
+            _featureOwners[endpoint] = featureName;
+    }
+
     /// <summary>
     /// Applies shell metadata and path prefix to an endpoint.
     /// </summary>
@@ -65,8 +80,14 @@ public class ShellEndpointRouteBuilder(
         }
 
         // Add shell metadata
+        var featureName = _featureOwners.TryGetValue(endpoint, out var owner) ? owner : null;
         var metadata = new EndpointMetadataCollection(
-            routeEndpoint.Metadata.Concat([new ShellEndpointMetadata(shellId, generation, shellSettings)]));
+            routeEndpoint.Metadata
+                .Where(item => item is not ShellEndpointMetadata && item is not EndpointOwnershipMetadata)
+                .Concat([
+                new ShellEndpointMetadata(shellId, generation, shellSettings, featureName),
+                new EndpointOwnershipMetadata(EndpointOwnerKind.DynamicShell, featureName ?? shellId.Name, shellId, generation),
+                ]));
 
         return new RouteEndpoint(
             routeEndpoint.RequestDelegate!,

--- a/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/CShells/DependencyInjection/ServiceCollectionExtensions.cs
@@ -116,7 +116,8 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<ShellProviderBuilder>(),
             sp,
             sp.GetService<ILogger<ShellRegistry>>(),
-            sp.GetServices<IShellLifecycleSubscriber>()));
+            sp.GetServices<IShellLifecycleSubscriber>(),
+            sp.GetServices<IShellGenerationActivationParticipant>()));
         services.TryAddSingleton<IShellRegistry>(sp => sp.GetRequiredService<ShellRegistry>());
 
         services.TryAddSingleton<IDrainPolicy>(_ => new Lifecycle.Policies.FixedTimeoutDrainPolicy(TimeSpan.FromSeconds(30)));

--- a/src/CShells/Hosting/DefaultShellServiceExclusionProvider.cs
+++ b/src/CShells/Hosting/DefaultShellServiceExclusionProvider.cs
@@ -39,6 +39,7 @@ public class DefaultShellServiceExclusionProvider : IShellServiceExclusionProvid
         yield return typeof(DrainGracePeriod);
         yield return typeof(Lifecycle.ShellLifecycleLogger);
         yield return typeof(IShellLifecycleSubscriber);
+        yield return typeof(IShellGenerationActivationParticipant);
         yield return typeof(IShellBlueprint);
         yield return typeof(RuntimeFeatureCatalog);
         // Excluded here AND re-registered as a root delegation in ShellProviderBuilder so shells can read the

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -433,19 +433,34 @@ internal sealed class ShellRegistry : IShellRegistry
         if (snapshot.IsEmpty)
             return;
 
+        ShellGenerationActivationException? activationFailure = null;
+
         foreach (var subscriber in snapshot)
         {
             try
             {
                 await subscriber.OnStateChangedAsync(shell, previous, current, cancellationToken).ConfigureAwait(false);
             }
+            catch (ShellGenerationActivationException ex)
+            {
+                // Candidate publication is the one subscriber failure that must abort the
+                // generation. Continue notifying peers first so subscriber isolation remains
+                // intact, then let the transition owner dispose the rejected candidate.
+                activationFailure ??= ex;
+                _logger.LogError(ex,
+                    "Shell generation publication failed in subscriber {SubscriberType} during {Previous} → {Current} for shell {Shell}",
+                    subscriber.GetType().FullName, previous, current, shell.Descriptor);
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex,
                     "Shell lifecycle subscriber {SubscriberType} threw during {Previous} → {Current} for shell {Shell}",
-                    subscriber.GetType().FullName, previous, current, shell.Descriptor);
+                subscriber.GetType().FullName, previous, current, shell.Descriptor);
             }
         }
+
+        if (activationFailure is not null)
+            throw activationFailure;
     }
 
     // =========================================================================
@@ -537,8 +552,19 @@ internal sealed class ShellRegistry : IShellRegistry
             throw;
         }
 
-        if (!await shell.TryTransitionAsync(ShellLifecycleState.Initializing, ShellLifecycleState.Active).ConfigureAwait(false))
-            throw new InvalidOperationException("Shell failed to transition from Initializing to Active.");
+        try
+        {
+            if (!await shell.TryTransitionAsync(ShellLifecycleState.Initializing, ShellLifecycleState.Active).ConfigureAwait(false))
+                throw new InvalidOperationException("Shell failed to transition from Initializing to Active.");
+        }
+        catch
+        {
+            // A publication subscriber can reject the candidate after the state CAS has moved it
+            // to Active. Dispose that unpublished generation before surfacing the failure so its
+            // provider, middleware, and collectible feature assemblies are not leaked.
+            await shell.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
 
         slot.Active = shell;
         // Atomic add: paired with the lock-free removal in ReleaseGeneration, which runs off the

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -584,6 +584,16 @@ internal sealed class ShellRegistry : IShellRegistry
 
             foreach (var participant in preparedParticipants)
                 participant.Commit(shell);
+
+            // Drain/disposal remains public and may race a slow later activation participant.
+            // A candidate removed from the slot while participant fan-out was blocked did not
+            // survive activation and must follow the rollback path rather than being reported as
+            // a successful (already disposed) generation.
+            if (!IsPublishedActiveGeneration(slot, shell))
+            {
+                throw new InvalidOperationException(
+                    $"Shell generation '{descriptor}' stopped being active before activation commit completed.");
+            }
         }
         catch (Exception ex)
         {
@@ -604,8 +614,8 @@ internal sealed class ShellRegistry : IShellRegistry
             // externally visible contribution. Once rollback completes, restore the prior slot.
             if (promoted)
             {
-                slot.Active = previousActive;
                 ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Remove(s), shell);
+                RestorePreviousActive(slot, previousActive);
             }
 
             // Dispose the rejected generation only after restoring the prior registry identity.
@@ -632,13 +642,31 @@ internal sealed class ShellRegistry : IShellRegistry
             }
         }
 
-        // Safe-by-construction guard against an add-after-release: if this generation somehow already
-        // reached Disposed before the add above (unreachable today — a drained initializer fails the
-        // Initializing→Active CAS at TryTransitionAsync and throws before we get here), its Disposed
-        // callback's Remove ran against a list that did not yet contain it and was a no-op, so the add
-        // just re-inserted a disposed shell. Re-run the release now rather than leak it back in.
-        if (shell.State == ShellLifecycleState.Disposed)
-            ReleaseGeneration(slot, shell);
+        // Completion is synchronous, but lifecycle cleanup can run concurrently between the commit
+        // eligibility check above and this return boundary. Never return a generation that has already
+        // been removed or disposed. This is a defensive backstop; cleanup that wins before commit
+        // completion takes the transactional catch path above, where participant rollback is available.
+        if (!IsPublishedActiveGeneration(slot, shell))
+        {
+            ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Remove(s), shell);
+            // Participants have already discarded rollback evidence, so prior route/pipeline
+            // availability cannot be inferred here. Leave the slot empty for safe reactivation.
+            ClearActiveIf(slot, shell);
+            if (previousActive is not null
+                && previousActive.State == ShellLifecycleState.Active
+                && slot.All.Contains(previousActive))
+            {
+                // The prior generation cannot be restored without participant rollback evidence.
+                // Drain it instead of leaving an unaddressable Active generation beside the next
+                // recovery activation.
+                _ = await DrainAsync(previousActive, CancellationToken.None).ConfigureAwait(false);
+            }
+            await shell.DisposeAsync().ConfigureAwait(false);
+            throw new ShellGenerationActivationException(
+                descriptor,
+                new InvalidOperationException(
+                    $"Shell generation '{descriptor}' stopped being active before activation completed."));
+        }
 
         _logger.LogInformation("Activated shell {Descriptor} with {FeatureCount} feature(s)",
             descriptor, buildResult.EnabledFeatures.Count);
@@ -692,8 +720,36 @@ internal sealed class ShellRegistry : IShellRegistry
         // on host shutdown — clear Active too, so GetActive never returns a Disposed shell that GetAll no
         // longer holds. Atomic CAS: a concurrent reload that already promoted a newer generation into
         // Active leaves it untouched (the stored reference no longer matches `typed`).
+        ClearActiveIf(slot, typed);
+    }
+
+    private static bool IsPublishedActiveGeneration(NameSlot slot, Shell shell) =>
+        shell.State == ShellLifecycleState.Active
+        && ReferenceEquals(slot.Active, shell)
+        && slot.All.Contains(shell);
+
+    private static void RestorePreviousActive(NameSlot slot, Shell? previousActive)
+    {
+        if (previousActive is null
+            || previousActive.State != ShellLifecycleState.Active
+            || !slot.All.Contains(previousActive))
+        {
+            slot.Active = null;
+            return;
+        }
+
+        slot.Active = previousActive;
+
+        // ReleaseGeneration can remove the prior generation without the name semaphore. Close the
+        // check/publish race: if cleanup won while it was being restored, clear only that stale value.
+        if (previousActive.State != ShellLifecycleState.Active || !slot.All.Contains(previousActive))
+            ClearActiveIf(slot, previousActive);
+    }
+
+    private static void ClearActiveIf(NameSlot slot, Shell shell)
+    {
 #pragma warning disable 420 // Interlocked provides the fence; other volatile reads/writes of Active are unaffected.
-        Interlocked.CompareExchange(ref slot.Active, null, typed);
+        Interlocked.CompareExchange(ref slot.Active, null, shell);
 #pragma warning restore 420
     }
 

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -17,6 +17,7 @@ internal sealed class ShellRegistry : IShellRegistry
     private readonly IServiceProvider? _rootProvider;
     private readonly IShellBlueprintProvider _blueprintProvider;
     private readonly ILogger<ShellRegistry> _logger;
+    private readonly IReadOnlyList<IShellGenerationActivationParticipant> _activationParticipants;
     private readonly ConcurrentDictionary<string, NameSlot> _slots = new(StringComparer.OrdinalIgnoreCase);
     private ImmutableList<IShellLifecycleSubscriber> _subscribers = [];
 
@@ -25,12 +26,14 @@ internal sealed class ShellRegistry : IShellRegistry
         ShellProviderBuilder? providerBuilder = null,
         IServiceProvider? rootProvider = null,
         ILogger<ShellRegistry>? logger = null,
-        IEnumerable<IShellLifecycleSubscriber>? subscribers = null)
+        IEnumerable<IShellLifecycleSubscriber>? subscribers = null,
+        IEnumerable<IShellGenerationActivationParticipant>? activationParticipants = null)
     {
         _blueprintProvider = Guard.Against.Null(blueprintProvider);
         _providerBuilder = providerBuilder;
         _rootProvider = rootProvider;
         _logger = logger ?? NullLogger<ShellRegistry>.Instance;
+        _activationParticipants = activationParticipants?.ToList() ?? [];
 
         // Subscribers registered in DI are subscribed at construction time so they observe
         // every transition — including the first activation kicked off by the startup hosted
@@ -46,7 +49,13 @@ internal sealed class ShellRegistry : IShellRegistry
 
     // Convenience ctor used by tests that don't need the provider-build pipeline.
     internal ShellRegistry(IShellBlueprintProvider blueprintProvider, ILogger<ShellRegistry>? logger)
-        : this(blueprintProvider, providerBuilder: null, rootProvider: null, logger, subscribers: null)
+        : this(
+            blueprintProvider,
+            providerBuilder: null,
+            rootProvider: null,
+            logger,
+            subscribers: null,
+            activationParticipants: null)
     {
     }
 
@@ -552,24 +561,76 @@ internal sealed class ShellRegistry : IShellRegistry
             throw;
         }
 
+        var previousActive = slot.Active;
+        var preparedParticipants = new List<IShellGenerationActivationParticipant>(_activationParticipants.Count);
+        var promoted = false;
         try
         {
+            foreach (var participant in _activationParticipants)
+            {
+                preparedParticipants.Add(participant);
+                await participant.PrepareAsync(shell, cancellationToken).ConfigureAwait(false);
+            }
+
             if (!await shell.TryTransitionAsync(ShellLifecycleState.Initializing, ShellLifecycleState.Active).ConfigureAwait(false))
                 throw new InvalidOperationException("Shell failed to transition from Initializing to Active.");
+
+            // Publish registry identity before committing participant state. Endpoint routing can
+            // observe a committed generation immediately, so exact-generation lookup must already
+            // resolve it at that first external visibility point.
+            slot.Active = shell;
+            ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Add(s), shell);
+            promoted = true;
+
+            foreach (var participant in preparedParticipants)
+                participant.Commit(shell);
         }
-        catch
+        catch (Exception ex)
         {
-            // A publication subscriber can reject the candidate after the state CAS has moved it
-            // to Active. Dispose that unpublished generation before surfacing the failure so its
-            // provider, middleware, and collectible feature assemblies are not leaked.
+            for (var i = preparedParticipants.Count - 1; i >= 0; i--)
+            {
+                try
+                {
+                    preparedParticipants[i].Rollback(shell);
+                }
+                catch (Exception rollbackException)
+                {
+                    _logger.LogError(rollbackException,
+                        "Activation participant rollback failed for shell {Shell}", shell.Descriptor);
+                }
+            }
+
+            // Keep the candidate registry-resolvable until participant rollback removes every
+            // externally visible contribution. Once rollback completes, restore the prior slot.
+            if (promoted)
+            {
+                slot.Active = previousActive;
+                ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Remove(s), shell);
+            }
+
+            // Dispose the rejected generation only after restoring the prior registry identity.
+            // Its Disposed lifecycle notification may perform idempotent participant cleanup.
             await shell.DisposeAsync().ConfigureAwait(false);
-            throw;
+            if (ex is ShellGenerationActivationException)
+                throw;
+            throw new ShellGenerationActivationException(descriptor, ex);
         }
 
-        slot.Active = shell;
-        // Atomic add: paired with the lock-free removal in ReleaseGeneration, which runs off the
-        // drain background thread (outside this name's semaphore) when a generation reaches Disposed.
-        ImmutableInterlocked.Update(ref slot.All, static (list, s) => list.Add(s), shell);
+        // Completion only releases rollback evidence after every commit succeeded. It is not an
+        // acceptance phase: rolling back here would be unsafe because an earlier participant may
+        // already have discarded the state needed to restore the prior generation.
+        foreach (var participant in preparedParticipants)
+        {
+            try
+            {
+                participant.Complete(shell);
+            }
+            catch (Exception completionException)
+            {
+                _logger.LogError(completionException,
+                    "Activation participant completion failed for shell {Shell}", shell.Descriptor);
+            }
+        }
 
         // Safe-by-construction guard against an add-after-release: if this generation somehow already
         // reached Disposed before the add above (unreachable today — a drained initializer fails the

--- a/src/CShells/Lifecycle/ShellRegistry.cs
+++ b/src/CShells/Lifecycle/ShellRegistry.cs
@@ -433,7 +433,7 @@ internal sealed class ShellRegistry : IShellRegistry
         if (snapshot.IsEmpty)
             return;
 
-        ShellGenerationActivationException? activationFailure = null;
+        var activationFailure = (ShellGenerationActivationException?)null;
 
         foreach (var subscriber in snapshot)
         {

--- a/tests/CShells.DynamicFeatureFixture/CShells.DynamicFeatureFixture.csproj
+++ b/tests/CShells.DynamicFeatureFixture/CShells.DynamicFeatureFixture.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>CShells.DynamicFeatureFixture</AssemblyName>
+    <RootNamespace>CShells.DynamicFeatureFixture</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CShells.AspNetCore.Abstractions\CShells.AspNetCore.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CShells.DynamicFeatureFixture/DynamicFeature.cs
+++ b/tests/CShells.DynamicFeatureFixture/DynamicFeature.cs
@@ -1,0 +1,28 @@
+using CShells.AspNetCore.Features;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CShells.DynamicFeatureFixture;
+
+/// <summary>
+/// A deliberately separate feature assembly used to prove that published endpoint delegates
+/// do not retain a collectible feature load context after the generation is retired.
+/// </summary>
+public sealed class DynamicFeature : IWebShellFeature
+{
+    /// <inheritdoc />
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    /// <inheritdoc />
+    public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment)
+    {
+        endpoints.MapGet("/collectible-feature", HandleRequest);
+    }
+
+    private static IResult HandleRequest() => Results.Ok("collectible-feature");
+}

--- a/tests/CShells.Tests/CShells.Tests.csproj
+++ b/tests/CShells.Tests/CShells.Tests.csproj
@@ -5,6 +5,7 @@
         <ProjectReference Include="..\..\src\CShells.AspNetCore\CShells.AspNetCore.csproj"/>
         <ProjectReference Include="..\..\src\CShells.FastEndpoints\CShells.FastEndpoints.csproj"/>
         <ProjectReference Include="..\..\src\CShells.Management.Api\CShells.Management.Api.csproj"/>
+        <ProjectReference Include="..\CShells.DynamicFeatureFixture\CShells.DynamicFeatureFixture.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -315,23 +315,94 @@ public class DynamicShellEndpointDataSourceTests
             [CreateEndpoint("api/three", shellId, 3, settings)]);
 
         generationTwo.Commit();
-        rejectedGenerationThree.Dispose();
+        Assert.Throws<InvalidOperationException>(() => rejectedGenerationThree.Commit());
+        generationTwo.Rollback();
 
+        rejectedGenerationThree.Commit();
+        rejectedGenerationThree.Rollback();
+
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        Assert.Equal("api/one", ((RouteEndpoint)dataSource.Endpoints.Single()).RoutePattern.RawText);
+    }
+
+    [Fact(DisplayName = "Completing a committed publication allows the next prepared generation to commit")]
+    public void PrepareGeneration_Complete_AllowsNextCommit()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("complete");
+        var settings = new ShellSettings(shellId);
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/one", shellId, 1, settings)]);
+        using var generationTwo = dataSource.PrepareGeneration(
+            shellId,
+            2,
+            [CreateEndpoint("api/two", shellId, 2, settings)]);
         using var generationThree = dataSource.PrepareGeneration(
             shellId,
             3,
             [CreateEndpoint("api/three", shellId, 3, settings)]);
-        using var generationFour = dataSource.PrepareGeneration(
-            shellId,
-            4,
-            [CreateEndpoint("api/four", shellId, 4, settings)]);
-        generationThree.Commit();
-        generationFour.Commit();
-        generationThree.Rollback();
-        generationFour.Complete();
 
-        AssertGeneration(dataSource, expectedGeneration: 4);
-        Assert.Equal("api/four", ((RouteEndpoint)dataSource.Endpoints.Single()).RoutePattern.RawText);
+        generationTwo.Commit();
+        generationTwo.Complete();
+        generationThree.Commit();
+        generationThree.Complete();
+
+        AssertGeneration(dataSource, expectedGeneration: 3);
+    }
+
+    [Fact(DisplayName = "Same-shell mutations are rejected while a committed publication retains rollback evidence")]
+    public void PrepareGeneration_PendingCommit_GuardsSameShellMutations()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("guarded");
+        var settings = new ShellSettings(shellId);
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/one", shellId, 1, settings)]);
+        using var generationTwo = dataSource.PrepareGeneration(
+            shellId,
+            2,
+            [CreateEndpoint("api/two", shellId, 2, settings)]);
+        generationTwo.Commit();
+
+        Assert.Throws<InvalidOperationException>(() => dataSource.AddEndpoints(
+            [CreateEndpoint("api/add", shellId, 2, settings)]));
+        Assert.Throws<InvalidOperationException>(() => dataSource.AddEndpoints(
+            [CreateHostEndpoint("api/one", "conflicting host endpoint", ["GET"])]));
+        Assert.Throws<InvalidOperationException>(() => dataSource.SetHostEndpoints(
+            [CreateHostEndpoint("api/one", "conflicting host inventory", ["GET"])]));
+        Assert.Throws<InvalidOperationException>(() => dataSource.RemoveEndpoints(shellId));
+        Assert.Throws<InvalidOperationException>(() => dataSource.RemoveEndpoints(shellId, 2));
+        Assert.Throws<InvalidOperationException>(() => dataSource.RetireGeneration(shellId, 2));
+        Assert.Throws<InvalidOperationException>(dataSource.Clear);
+
+        generationTwo.Rollback();
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        dataSource.RemoveEndpoints(shellId);
+        Assert.Empty(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "A pending commit blocks cross-shell publication until rollback evidence is released")]
+    public void PrepareGeneration_PendingCommit_GuardsCrossShellPublication()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellA = new ShellId("a");
+        var shellB = new ShellId("b");
+        var settingsA = new ShellSettings(shellA);
+        var settingsB = new ShellSettings(shellB);
+        dataSource.PublishGeneration(shellA, 1, [CreateEndpoint("api/retired", shellA, 1, settingsA)]);
+        using var publicationA = dataSource.PrepareGeneration(
+            shellA,
+            2,
+            [CreateEndpoint("api/current", shellA, 2, settingsA)]);
+        publicationA.Commit();
+        using var publicationB = dataSource.PrepareGeneration(
+            shellB,
+            1,
+            [CreateEndpoint("api/retired", shellB, 1, settingsB)]);
+
+        Assert.Throws<InvalidOperationException>(() => publicationB.Commit());
+
+        publicationA.Rollback();
+        Assert.Throws<ShellEndpointConflictException>(() => publicationB.Commit());
+        Assert.Equal(shellA, dataSource.Endpoints.Single().Metadata.GetMetadata<ShellEndpointMetadata>()!.ShellId);
     }
 
     [Fact(DisplayName = "Prepared publications revalidate conflicts at commit")]
@@ -351,6 +422,7 @@ public class DynamicShellEndpointDataSourceTests
             [CreateEndpoint("api/shared", shellB, 1, settings, "FeatureB")]);
 
         publicationA.Commit();
+        publicationA.Complete();
         var exception = Assert.Throws<ShellEndpointConflictException>(() => publicationB.Commit());
 
         Assert.Equal("FeatureB", exception.Conflict.CandidateOwner.OwnerId);

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,11 +1,16 @@
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
 using CShells.AspNetCore.Notifications;
+using CShells.AspNetCore.Features;
 using CShells.Features;
 using CShells.Lifecycle;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
 
 namespace CShells.Tests.Integration.AspNetCore;
 
@@ -114,17 +119,150 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Empty(dataSource.Endpoints);
     }
 
-    private static RouteEndpoint CreateEndpoint(string pattern, ShellId shellId, int generation, ShellSettings settings)
+    [Fact(DisplayName = "PublishGeneration rejects equivalent templates and preserves the previous snapshot")]
+    public void PublishGeneration_EquivalentTemplates_PreservesPreviousSnapshot()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items/{id}", shellId, 1, settings, "FeatureV1")]);
+
+        var conflictingShell = new ShellId("other");
+        var exception = Assert.Throws<ShellEndpointConflictException>(() =>
+            dataSource.PublishGeneration(conflictingShell, 1, [CreateEndpoint("api/items/{name}", conflictingShell, 1, settings, "FeatureV2")]));
+
+        Assert.Contains("DynamicShell:FeatureV2", exception.Message);
+        Assert.Contains("DynamicShell:FeatureV1", exception.Message);
+        var remaining = Assert.Single(dataSource.Endpoints);
+        Assert.Equal("default", remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.ShellId.Name);
+    }
+
+    [Fact(DisplayName = "PublishGeneration rejects overlapping multi-method routes")]
+    public void PublishGeneration_OverlappingMethods_RejectsCandidate()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellA = new ShellId("a");
+        var shellB = new ShellId("b");
+        var settings = new ShellSettings();
+
+        dataSource.PublishGeneration(shellA, 1, [CreateEndpoint("api/items", shellA, 1, settings, "A", ["POST"])]);
+
+        var exception = Assert.Throws<ShellEndpointConflictException>(() =>
+            dataSource.PublishGeneration(shellB, 1, [CreateEndpoint("api/items", shellB, 1, settings, "B", ["GET", "POST"])]));
+
+        Assert.Contains("DynamicShell:B", exception.Message);
+        Assert.Contains("DynamicShell:A", exception.Message);
+        Assert.Single(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "PublishGeneration rejects same-batch collisions before publication")]
+    public void PublishGeneration_SameBatchCollision_LeavesSnapshotUnchanged()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+
+        var exception = Assert.Throws<ShellEndpointConflictException>(() =>
+            dataSource.PublishGeneration(shellId, 1,
+            [
+                CreateEndpoint("api/items/{id}", shellId, 1, settings, "First"),
+                CreateEndpoint("api/items/{name}", shellId, 1, settings, "Second"),
+            ]));
+
+        Assert.Contains("DynamicShell:First", exception.Message);
+        Assert.Contains("DynamicShell:Second", exception.Message);
+        Assert.Empty(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "PublishGeneration rejects host conflicts with deterministic host owner")]
+    public void PublishGeneration_HostConflict_IdentifiesBothOwners()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+        dataSource.SetHostEndpoints([CreateHostEndpoint("api/items", "Host API", ["GET"])]);
+
+        var exception = Assert.Throws<ShellEndpointConflictException>(() =>
+            dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items", shellId, 1, settings, "Feature", ["GET"])]));
+
+        Assert.Contains("DynamicShell:Feature", exception.Message);
+        Assert.Contains("Host:Host API", exception.Message);
+        Assert.Empty(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "PublishGeneration swaps complete snapshots without exposing an empty state")]
+    public void PublishGeneration_SuccessfulReplacement_ExposesOnlyCompleteSnapshots()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items", shellId, 1, settings, "FeatureV1")]);
+
+        IReadOnlyList<Endpoint>? observed = null;
+        using var registration = dataSource.GetChangeToken().RegisterChangeCallback(_ => observed = dataSource.Endpoints, null);
+        dataSource.PublishGeneration(shellId, 2,
+        [
+            CreateEndpoint("api/items", shellId, 2, settings, "FeatureV2"),
+            CreateEndpoint("api/status", shellId, 2, settings, "FeatureV2"),
+        ]);
+
+        Assert.NotNull(observed);
+        Assert.Equal(2, observed!.Count);
+        Assert.All(observed, endpoint => Assert.Equal(2, endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation));
+    }
+
+    [Fact(DisplayName = "Failed feature mapping preserves the previously published generation")]
+    public void RegisterActiveShell_MappingFailure_PreservesPreviousGeneration()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings(shellId, ["Broken"]);
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items", shellId, 1, settings, "FeatureV1")]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(settings);
+        services.AddSingleton<IEnumerable<ShellFeatureDescriptor>>(
+            [new ShellFeatureDescriptor("Broken") { StartupType = typeof(ThrowingWebFeature) }]);
+        var shell = new TestShell(ShellDescriptor.Create("default", 2), services.BuildServiceProvider());
+        var handler = new ShellEndpointRegistrationHandler(
+            dataSource,
+            new ThrowingFeatureFactory(),
+            new EndpointRouteBuilderAccessor { EndpointRouteBuilder = new TestEndpointRouteBuilder(shell.ServiceProvider) },
+            new ApplicationBuilderAccessor { ApplicationBuilder = new ApplicationBuilder(shell.ServiceProvider) },
+            new ShellMiddlewarePipelineRegistry());
+
+        Assert.Throws<InvalidOperationException>(() => handler.RegisterActiveShell(shell));
+        var remaining = Assert.Single(dataSource.Endpoints);
+        Assert.Equal(1, remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    private static RouteEndpoint CreateEndpoint(
+        string pattern,
+        ShellId shellId,
+        int generation,
+        ShellSettings settings,
+        string featureName = "Feature",
+        IReadOnlyList<string>? methods = null)
     {
         return new RouteEndpoint(
             _ => Task.CompletedTask,
             RoutePatternFactory.Parse(pattern),
             order: 0,
             new EndpointMetadataCollection(
-                new ShellEndpointMetadata(shellId, generation, settings),
-                new HttpMethodMetadata(["GET"])),
+                new ShellEndpointMetadata(shellId, generation, settings, featureName),
+                new EndpointOwnershipMetadata(EndpointOwnerKind.DynamicShell, featureName, shellId, generation),
+                new HttpMethodMetadata(methods ?? ["GET"])),
             displayName: $"{pattern} (gen {generation})");
     }
+
+    private static RouteEndpoint CreateHostEndpoint(string pattern, string displayName, IReadOnlyList<string> methods) =>
+        new(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            new EndpointMetadataCollection(new HttpMethodMetadata(methods)),
+            displayName);
 
     private sealed class FakeShell(ShellDescriptor descriptor, ShellLifecycleState state) : IShell
     {
@@ -144,5 +282,36 @@ public class DynamicShellEndpointDataSourceTests
         public T CreateFeature<T>(Type featureType, ShellSettings? shellSettings = null, ShellFeatureContext? featureContext = null)
             where T : class =>
             throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingFeatureFactory : IShellFeatureFactory
+    {
+        public T CreateFeature<T>(Type featureType, ShellSettings? shellSettings = null, ShellFeatureContext? featureContext = null)
+            where T : class =>
+            (T)(object)new ThrowingWebFeature();
+    }
+
+    private sealed class ThrowingWebFeature : IWebShellFeature
+    {
+        public void ConfigureServices(IServiceCollection services) { }
+
+        public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+            throw new InvalidOperationException("mapping failed");
+    }
+
+    private sealed class TestShell(ShellDescriptor descriptor, IServiceProvider provider) : IShell
+    {
+        public ShellDescriptor Descriptor { get; } = descriptor;
+        public ShellLifecycleState State => ShellLifecycleState.Active;
+        public IServiceProvider ServiceProvider { get; } = provider;
+        public IDrainOperation? Drain => null;
+        public IShellScope BeginScope() => throw new NotSupportedException();
+    }
+
+    private sealed class TestEndpointRouteBuilder(IServiceProvider provider) : IEndpointRouteBuilder
+    {
+        public IServiceProvider ServiceProvider { get; } = provider;
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
     }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -707,6 +707,121 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Single(dataSource.Endpoints);
     }
 
+    [Fact(DisplayName = "A rejected candidate does not restore a prior generation that drained during commit")]
+    public async Task PendingCommit_PriorGenerationDrainsThenCandidateRejects_RecoversWithoutDisposedRoutes()
+    {
+        const string shellName = "cleanup-prior";
+        var blocker = new BlockingActivationParticipant(shellName, generation: 2, rejectAfterRelease: true);
+        await using var host = CreateStableShellHost(shellName, blocker);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var generationOne = await registry.ActivateAsync(shellName);
+        var reloadTask = Task.Run(() => registry.ReloadAsync(shellName));
+
+        await blocker.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            var drain = await registry.DrainAsync(generationOne);
+            await drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+
+            var rollbackSnapshot = new TaskCompletionSource<IReadOnlyList<Endpoint>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = dataSource.GetChangeToken().RegisterChangeCallback(
+                _ => rollbackSnapshot.TrySetResult(dataSource.Endpoints.ToArray()),
+                null);
+
+            blocker.Release();
+            var reload = await reloadTask.WaitAsync(TimeSpan.FromSeconds(5));
+            var observed = await rollbackSnapshot.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.IsType<ShellGenerationActivationException>(reload.Error);
+            Assert.Null(reload.NewShell);
+            Assert.Empty(observed);
+            Assert.Empty(dataSource.Endpoints);
+            Assert.Null(registry.GetActive(shellName));
+            Assert.DoesNotContain(generationOne, registry.GetAll(shellName));
+            var recovered = await AssertRecoveredGenerationServesAsync(host, shellName);
+            Assert.Equal(3, recovered.Descriptor.Generation);
+        }
+        finally
+        {
+            blocker.Release();
+        }
+    }
+
+    [Fact(DisplayName = "A candidate that drains during commit is rejected and the prior generation remains live")]
+    public async Task PendingCommit_CandidateDrainsThenParticipantsAccept_DoesNotReturnDisposedGeneration()
+    {
+        const string shellName = "cleanup-candidate";
+        var blocker = new BlockingActivationParticipant(shellName, generation: 2);
+        await using var host = CreateStableShellHost(shellName, blocker);
+
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var generationOne = await registry.ActivateAsync(shellName);
+        var reloadTask = Task.Run(() => registry.ReloadAsync(shellName));
+
+        await blocker.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        var candidate = (IShell?)null;
+        try
+        {
+            candidate = Assert.IsAssignableFrom<IShell>(registry.GetActive(shellName));
+            Assert.Equal(2, candidate.Descriptor.Generation);
+            var drain = await registry.DrainAsync(candidate);
+            await drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(ShellLifecycleState.Disposed, candidate.State);
+        }
+        finally
+        {
+            blocker.Release();
+        }
+
+        var reload = await reloadTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var rejectedCandidate = Assert.IsAssignableFrom<IShell>(candidate);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.DoesNotContain(rejectedCandidate, registry.GetAll(shellName));
+        Assert.DoesNotContain(registry.GetActiveShells(), shell => shell.State == ShellLifecycleState.Disposed);
+        Assert.Same(generationOne, registry.GetActive(shellName));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        var recovered = await AssertRecoveredGenerationServesAsync(host, shellName);
+        Assert.Same(generationOne, recovered);
+    }
+
+    [Fact(DisplayName = "A candidate drained during completion leaves the slot safe for reactivation")]
+    public async Task Reload_CandidateDrainsDuringParticipantCompletion_ReactivatesWithoutZombieGeneration()
+    {
+        const string shellName = "cleanup-completion";
+        var drainer = new DrainCandidateOnCompletionParticipant();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell(shellName, shell => shell.WithFeature<RollbackStableFeature>()));
+        services.AddSingleton<IShellGenerationActivationParticipant>(drainer);
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        drainer.AttachRegistry(registry);
+        var generationOne = await registry.ActivateAsync(shellName);
+
+        var reload = await registry.ReloadAsync(shellName);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.NotNull(drainer.DrainedShell);
+        Assert.Equal(ShellLifecycleState.Disposed, drainer.DrainedShell.State);
+        Assert.NotEqual(ShellLifecycleState.Active, generationOne.State);
+        Assert.Null(registry.GetActive(shellName));
+        Assert.Empty(dataSource.Endpoints);
+        var recovered = await AssertRecoveredGenerationServesAsync(host, shellName);
+        Assert.Equal(3, recovered.Descriptor.Generation);
+    }
+
     [Fact(DisplayName = "Repeated collectible feature generations unload after replacement and removal")]
     public async Task CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval()
     {
@@ -832,6 +947,22 @@ public class DynamicShellEndpointDataSourceTests
         services.GetRequiredService<ApplicationBuilderAccessor>().ApplicationBuilder = new ApplicationBuilder(services);
     }
 
+    private static ServiceProvider CreateStableShellHost(
+        string shellName,
+        IShellGenerationActivationParticipant blocker)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell(shellName, shell => shell.WithFeature<RollbackStableFeature>()));
+        services.AddSingleton<IShellGenerationActivationParticipant>(blocker);
+
+        var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        return host;
+    }
+
     private static void AssertGeneration(DynamicShellEndpointDataSource dataSource, int expectedGeneration)
     {
         var endpoint = Assert.Single(dataSource.Endpoints);
@@ -849,6 +980,39 @@ public class DynamicShellEndpointDataSourceTests
         var context = new DefaultHttpContext();
         await pipeline!(context);
         Assert.Equal(expectedMarker, context.Items["pipeline-marker"]);
+    }
+
+    private static async Task<IShell> AssertRecoveredGenerationServesAsync(
+        IServiceProvider host,
+        string shellName)
+    {
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var recovered = await registry.GetOrActivateAsync(shellName);
+        Assert.Equal(ShellLifecycleState.Active, recovered.State);
+        Assert.Same(recovered, registry.GetActive(shellName));
+        Assert.DoesNotContain(registry.GetAll(shellName), shell => shell.State == ShellLifecycleState.Disposed);
+
+        var endpoint = Assert.Single(dataSource.Endpoints);
+        Assert.Equal(recovered.Descriptor.Generation,
+            endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+        var response = new ShellMiddlewareTests.FireableResponseFeature();
+        var context = new DefaultHttpContext { RequestServices = host };
+        context.Features.Set<Microsoft.AspNetCore.Http.Features.IHttpResponseFeature>(response);
+        context.SetEndpoint(endpoint);
+        var middleware = ShellMiddlewareTests.CreateMiddleware(
+            _ => Task.CompletedTask,
+            registry: registry,
+            endpointDataSource: dataSource,
+            pipelineRegistry: pipelines);
+
+        await middleware.InvokeAsync(context);
+        await response.FireOnCompletedAsync();
+
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal("stable", context.Items["pipeline-marker"]);
+        return recovered;
     }
 
     private sealed class CollectibleFeatureLoadContext : AssemblyLoadContext
@@ -1132,4 +1296,36 @@ public sealed class BlockingActivationParticipant(
     }
 
     public void Release() => release.TrySetResult();
+}
+
+internal sealed class DrainCandidateOnCompletionParticipant : IShellGenerationActivationParticipant
+{
+    private IShellRegistry? registry;
+
+    internal IShell? DrainedShell { get; private set; }
+
+    internal void AttachRegistry(IShellRegistry value) =>
+        registry = value;
+
+    public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public void Commit(IShell shell)
+    {
+    }
+
+    public void Complete(IShell shell)
+    {
+        if (shell.Descriptor.Generation != 2)
+            return;
+
+        DrainedShell = shell;
+        var currentRegistry = registry ?? throw new InvalidOperationException("The registry was not attached.");
+        var drain = currentRegistry.DrainAsync(shell).GetAwaiter().GetResult();
+        drain.WaitAsync().GetAwaiter().GetResult();
+    }
+
+    public void Rollback(IShell shell)
+    {
+    }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
 using CShells.AspNetCore.Notifications;
@@ -235,6 +238,116 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Throws<InvalidOperationException>(() => handler.RegisterActiveShell(shell));
         var remaining = Assert.Single(dataSource.Endpoints);
         Assert.Equal(1, remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    [Fact(DisplayName = "Repeated collectible feature generations unload after replacement and removal")]
+    public async Task CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("collectible");
+        var fixtureAssemblyPath = Path.Combine(AppContext.BaseDirectory, "CShells.DynamicFeatureFixture.dll");
+
+        Assert.True(File.Exists(fixtureAssemblyPath), $"Dynamic feature fixture was not copied to '{fixtureAssemblyPath}'.");
+
+        for (var cycle = 1; cycle <= 5; cycle++)
+        {
+            var loadContext = MapReplaceAndRemoveCollectibleGeneration(
+                dataSource,
+                shellId,
+                generation: cycle * 2 - 1,
+                fixtureAssemblyPath);
+
+            Assert.Empty(dataSource.Endpoints);
+            await AssertCollectibleAsync(loadContext, cycle);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference MapReplaceAndRemoveCollectibleGeneration(
+        DynamicShellEndpointDataSource dataSource,
+        ShellId shellId,
+        int generation,
+        string fixtureAssemblyPath)
+    {
+        var loadContext = new CollectibleFeatureLoadContext();
+        var loadContextWeakReference = new WeakReference(loadContext);
+        var fixtureAssembly = loadContext.LoadFromAssemblyPath(fixtureAssemblyPath);
+        var featureType = fixtureAssembly.GetType(
+            "CShells.DynamicFeatureFixture.DynamicFeature",
+            throwOnError: true)!;
+
+        Assert.Same(loadContext, AssemblyLoadContext.GetLoadContext(featureType.Assembly));
+
+        var feature = (IWebShellFeature)Activator.CreateInstance(featureType)!;
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var innerBuilder = new TestEndpointRouteBuilder(serviceProvider);
+        var shellSettings = new ShellSettings(shellId);
+        var shellBuilder = new ShellEndpointRouteBuilder(
+            innerBuilder,
+            shellId,
+            generation,
+            shellSettings,
+            serviceProvider,
+            pathPrefix: null);
+
+        // Use the same route-builder seam used by ShellEndpointRegistrationHandler: feature code
+        // maps into ShellEndpointRouteBuilder, which materializes the complete candidate before
+        // DynamicShellEndpointDataSource publishes it.
+        feature.MapEndpoints(shellBuilder, environment: null);
+        var collectibleCandidate = shellBuilder.GetEndpoints().ToArray();
+        Assert.Single(collectibleCandidate);
+        dataSource.PublishGeneration(shellId, generation, collectibleCandidate);
+
+        // Replacing the candidate retires its endpoint while publishing the next complete
+        // snapshot. Drive the replacement through the lifecycle handler's Draining transition
+        // so the test exercises the same removal seam used by a real shell drain.
+        var replacementSettings = new ShellSettings(shellId);
+        dataSource.PublishGeneration(
+            shellId,
+            generation + 1,
+            [CreateEndpoint("/replacement", shellId, generation + 1, replacementSettings, "Replacement")]);
+
+        var handler = new ShellEndpointRegistrationHandler(
+            dataSource,
+            new NoopFeatureFactory(),
+            new EndpointRouteBuilderAccessor(),
+            new ApplicationBuilderAccessor(),
+            new ShellMiddlewarePipelineRegistry());
+        var replacementShell = new FakeShell(
+            ShellDescriptor.Create(shellId.Name, generation + 1),
+            ShellLifecycleState.Draining);
+        handler.OnStateChangedAsync(replacementShell, ShellLifecycleState.Deactivating, ShellLifecycleState.Draining)
+            .GetAwaiter()
+            .GetResult();
+
+        loadContext.Unload();
+        return loadContextWeakReference;
+    }
+
+    private static async Task AssertCollectibleAsync(WeakReference loadContext, int cycle)
+    {
+        for (var attempt = 0; attempt < 40 && loadContext.IsAlive; attempt++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            await Task.Yield();
+        }
+
+        Assert.False(loadContext.IsAlive,
+            $"Collectible feature load context remained rooted after cycle {cycle}; " +
+            "published or retired endpoint state still retains feature assembly code.");
+    }
+
+    private sealed class CollectibleFeatureLoadContext : AssemblyLoadContext
+    {
+        public CollectibleFeatureLoadContext()
+            : base($"CShells.DynamicFeatureFixture-{Guid.NewGuid():N}", isCollectible: true)
+        {
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName) =>
+            AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
     }
 
     private static RouteEndpoint CreateEndpoint(

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
@@ -101,6 +102,62 @@ public class DynamicShellEndpointDataSourceTests
         dataSource.RemoveEndpoints(shellId, generation: 2);
 
         Assert.Equal(0, changes);
+        Assert.Single(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "A previously returned change token remains safe to register after publication")]
+    public void GetChangeToken_ConcurrentPublication_DoesNotDisposeReturnedToken()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("default");
+        var settings = new ShellSettings();
+        var token = dataSource.GetChangeToken();
+
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items", shellId, 1, settings)]);
+
+        using var registration = token.RegisterChangeCallback(_ => { }, null);
+        Assert.True(token.HasChanged);
+    }
+
+    [Fact(DisplayName = "Change-token reads and registrations remain safe during repeated publication")]
+    public async Task GetChangeToken_ParallelPublication_DoesNotRaceTokenDisposal()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("tokens");
+        var settings = new ShellSettings(shellId);
+        var errors = new ConcurrentQueue<Exception>();
+
+        var writer = Task.Run(() =>
+        {
+            for (var generation = 1; generation <= 2_000; generation++)
+            {
+                dataSource.PublishGeneration(
+                    shellId,
+                    generation,
+                    [CreateEndpoint("api/token", shellId, generation, settings)]);
+            }
+        });
+        var readers = Enumerable.Range(0, 4).Select(readerIndex => Task.Run(() =>
+        {
+            for (var attempt = 0; attempt < 2_000; attempt++)
+            {
+                try
+                {
+                    var token = dataSource.GetChangeToken();
+                    using var registration = token.RegisterChangeCallback(_ => { }, null);
+                    _ = token.HasChanged;
+                    _ = dataSource.Endpoints.Count;
+                }
+                catch (Exception ex)
+                {
+                    errors.Enqueue(ex);
+                }
+            }
+        }));
+
+        await Task.WhenAll(readers.Append(writer));
+
+        Assert.Empty(errors);
         Assert.Single(dataSource.Endpoints);
     }
 
@@ -241,6 +298,66 @@ public class DynamicShellEndpointDataSourceTests
         Assert.All(observed, endpoint => Assert.Equal(2, endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation));
     }
 
+    [Fact(DisplayName = "Overlapping prepared publications are linearized and rollback cannot restore an intermediate generation")]
+    public void PrepareGeneration_OverlappingCommitAndRollback_DoesNotResurrectRoutes()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var shellId = new ShellId("linear");
+        var settings = new ShellSettings(shellId);
+        dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/one", shellId, 1, settings)]);
+        using var generationTwo = dataSource.PrepareGeneration(
+            shellId,
+            2,
+            [CreateEndpoint("api/two", shellId, 2, settings)]);
+        using var rejectedGenerationThree = dataSource.PrepareGeneration(
+            shellId,
+            3,
+            [CreateEndpoint("api/three", shellId, 3, settings)]);
+
+        generationTwo.Commit();
+        rejectedGenerationThree.Dispose();
+
+        using var generationThree = dataSource.PrepareGeneration(
+            shellId,
+            3,
+            [CreateEndpoint("api/three", shellId, 3, settings)]);
+        using var generationFour = dataSource.PrepareGeneration(
+            shellId,
+            4,
+            [CreateEndpoint("api/four", shellId, 4, settings)]);
+        generationThree.Commit();
+        generationFour.Commit();
+        generationThree.Rollback();
+        generationFour.Complete();
+
+        AssertGeneration(dataSource, expectedGeneration: 4);
+        Assert.Equal("api/four", ((RouteEndpoint)dataSource.Endpoints.Single()).RoutePattern.RawText);
+    }
+
+    [Fact(DisplayName = "Prepared publications revalidate conflicts at commit")]
+    public void PrepareGeneration_ConcurrentConflict_SecondCommitIsRejected()
+    {
+        var dataSource = new DynamicShellEndpointDataSource();
+        var settings = new ShellSettings();
+        var shellA = new ShellId("a");
+        var shellB = new ShellId("b");
+        using var publicationA = dataSource.PrepareGeneration(
+            shellA,
+            1,
+            [CreateEndpoint("api/shared", shellA, 1, settings, "FeatureA")]);
+        using var publicationB = dataSource.PrepareGeneration(
+            shellB,
+            1,
+            [CreateEndpoint("api/shared", shellB, 1, settings, "FeatureB")]);
+
+        publicationA.Commit();
+        var exception = Assert.Throws<ShellEndpointConflictException>(() => publicationB.Commit());
+
+        Assert.Equal("FeatureB", exception.Conflict.CandidateOwner.OwnerId);
+        Assert.Equal("FeatureA", exception.Conflict.ExistingOwner.OwnerId);
+        Assert.Equal(shellA, dataSource.Endpoints.Single().Metadata.GetMetadata<ShellEndpointMetadata>()!.ShellId);
+    }
+
     [Fact(DisplayName = "Failed feature mapping preserves the previously published generation")]
     public void RegisterActiveShell_MappingFailure_PreservesPreviousGeneration()
     {
@@ -261,7 +378,8 @@ public class DynamicShellEndpointDataSourceTests
             new ApplicationBuilderAccessor { ApplicationBuilder = new ApplicationBuilder(shell.ServiceProvider) },
             new ShellMiddlewarePipelineRegistry());
 
-        Assert.Throws<InvalidOperationException>(() => handler.RegisterActiveShell(shell));
+        var exception = Assert.Throws<ShellGenerationActivationException>(() => handler.RegisterActiveShell(shell));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
         var remaining = Assert.Single(dataSource.Endpoints);
         Assert.Equal(1, remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
     }
@@ -326,6 +444,111 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Same(generationOne, registry.GetActive(shellId.Name));
         AssertGeneration(dataSource, expectedGeneration: 1);
         await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "composition");
+        Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
+    }
+
+    [Fact(DisplayName = "A provisional reload is not routing-visible while a later subscriber is still deciding")]
+    public async Task Reload_SlowLaterSubscriber_KeepsPriorGenerationRoutableUntilCommit()
+    {
+        var slowSubscriber = new SlowSecondGenerationSubscriber();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell("provisional", shell => shell.WithFeature<RollbackStableFeature>()));
+        services.AddSingleton<IShellLifecycleSubscriber>(slowSubscriber);
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("provisional");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+        var reloadTask = registry.ReloadAsync(shellId.Name);
+
+        await slowSubscriber.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        var visibleEndpoint = Assert.Single(dataSource.Endpoints);
+        var visibleGeneration = visibleEndpoint.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation;
+        var response = new ShellMiddlewareTests.FireableResponseFeature();
+        var context = new DefaultHttpContext();
+        context.Features.Set<Microsoft.AspNetCore.Http.Features.IHttpResponseFeature>(response);
+        context.SetEndpoint(visibleEndpoint);
+        var middleware = ShellMiddlewareTests.CreateMiddleware(
+            _ => Task.CompletedTask,
+            registry: registry,
+            endpointDataSource: dataSource,
+            pipelineRegistry: pipelines);
+
+        await middleware.InvokeAsync(context);
+        await response.FireOnCompletedAsync();
+        slowSubscriber.Release();
+        var reload = await reloadTask;
+
+        Assert.Equal(generationOne.Descriptor.Generation, visibleGeneration);
+        Assert.Equal("stable", context.Items["pipeline-marker"]);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Null(reload.Error);
+        Assert.Equal(2, dataSource.Endpoints.Single().Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    [Fact(DisplayName = "Commit conflict restores the prior registry generation and discards the staged pipeline")]
+    public async Task Reload_CommitConflict_RestoresPriorActiveAndAllEntries()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<HostConflictOnSecondCommitParticipant>();
+        services.AddSingleton<IShellGenerationActivationParticipant>(sp =>
+            sp.GetRequiredService<HostConflictOnSecondCommitParticipant>());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell("commit-conflict", shell => shell.WithFeature<RollbackStableFeature>()));
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("commit-conflict");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+
+        var reload = await registry.ReloadAsync(shellId.Name);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.Same(generationOne, registry.GetActive(shellId.Name));
+        Assert.Equal([generationOne], registry.GetAll(shellId.Name));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "stable");
+        Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
+    }
+
+    [Fact(DisplayName = "A later participant rejection rolls committed routes and pipeline back to the prior generation")]
+    public async Task Reload_LaterParticipantRejectsCommit_RestoresPriorRoutesAndPipeline()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell("later-rejection", shell => shell.WithFeature<RollbackStableFeature>()));
+        services.AddSingleton<IShellGenerationActivationParticipant, RejectSecondGenerationCommitParticipant>();
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("later-rejection");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+
+        var reload = await registry.ReloadAsync(shellId.Name);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.Same(generationOne, registry.GetActive(shellId.Name));
+        Assert.Equal([generationOne], registry.GetAll(shellId.Name));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "stable");
         Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
     }
 
@@ -415,7 +638,7 @@ public class DynamicShellEndpointDataSourceTests
 
     private static async Task AssertCollectibleAsync(WeakReference loadContext, int cycle)
     {
-        for (var attempt = 0; attempt < 40 && loadContext.IsAlive; attempt++)
+        for (var attempt = 0; attempt < 100 && loadContext.IsAlive; attempt++)
         {
             GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
             GC.WaitForPendingFinalizers();
@@ -603,4 +826,77 @@ public sealed class RejectSecondGenerationSubscriber : IShellLifecycleSubscriber
                 shell.Descriptor,
                 new InvalidOperationException("later subscriber rejected generation two"))
             : Task.CompletedTask;
+}
+
+public sealed class SlowSecondGenerationSubscriber : IShellLifecycleSubscriber
+{
+    private readonly TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Entered => entered.Task;
+
+    public void Release() => release.TrySetResult();
+
+    public async Task OnStateChangedAsync(
+        IShell shell,
+        ShellLifecycleState previous,
+        ShellLifecycleState current,
+        CancellationToken cancellationToken = default)
+    {
+        if (current != ShellLifecycleState.Active || shell.Descriptor.Generation != 2)
+            return;
+
+        entered.TrySetResult();
+        await release.Task.WaitAsync(cancellationToken);
+    }
+}
+
+public sealed class HostConflictOnSecondCommitParticipant(EndpointRouteBuilderAccessor routeBuilderAccessor) :
+    IShellGenerationActivationParticipant
+{
+    public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public void Commit(IShell shell)
+    {
+        if (shell.Descriptor.Generation != 2)
+            return;
+
+        var hostEndpoint = new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("/rollback"),
+            order: 0,
+            new EndpointMetadataCollection(new HttpMethodMetadata(["GET"])),
+            "Late host conflict");
+        routeBuilderAccessor.EndpointRouteBuilder!.DataSources.Add(
+            new DefaultEndpointDataSource(hostEndpoint));
+    }
+
+    public void Complete(IShell shell)
+    {
+    }
+
+    public void Rollback(IShell shell)
+    {
+    }
+}
+
+public sealed class RejectSecondGenerationCommitParticipant : IShellGenerationActivationParticipant
+{
+    public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public void Commit(IShell shell)
+    {
+        if (shell.Descriptor.Generation == 2)
+            throw new InvalidOperationException("later participant rejected generation two");
+    }
+
+    public void Complete(IShell shell)
+    {
+    }
+
+    public void Rollback(IShell shell)
+    {
+    }
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -342,7 +342,10 @@ public class DynamicShellEndpointDataSourceTests
             [CreateEndpoint("api/three", shellId, 3, settings)]);
 
         generationTwo.Commit();
+        dataSource.RemoveEndpoints(shellId, 2);
+        AssertGeneration(dataSource, expectedGeneration: 2);
         generationTwo.Complete();
+        Assert.Empty(dataSource.Endpoints);
         generationThree.Commit();
         generationThree.Complete();
 
@@ -369,8 +372,9 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Throws<InvalidOperationException>(() => dataSource.SetHostEndpoints(
             [CreateHostEndpoint("api/one", "conflicting host inventory", ["GET"])]));
         Assert.Throws<InvalidOperationException>(() => dataSource.RemoveEndpoints(shellId));
-        Assert.Throws<InvalidOperationException>(() => dataSource.RemoveEndpoints(shellId, 2));
-        Assert.Throws<InvalidOperationException>(() => dataSource.RetireGeneration(shellId, 2));
+        dataSource.RemoveEndpoints(shellId, 2);
+        dataSource.RetireGeneration(shellId, 2);
+        AssertGeneration(dataSource, expectedGeneration: 2);
         Assert.Throws<InvalidOperationException>(dataSource.Clear);
 
         generationTwo.Rollback();
@@ -624,6 +628,85 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
     }
 
+    [Fact(DisplayName = "Another shell can drain and release endpoints while a publication transaction is pending")]
+    public async Task PendingCommit_OtherShellDrain_RemovesEndpointsAndReleasesReferences()
+    {
+        var blocker = new BlockingActivationParticipant("cleanup-b", generation: 1);
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<CleanupFeatureA>()
+            .AddShell("cleanup-a", shell => shell.WithFeature<CleanupFeatureA>())
+            .AddShell("cleanup-b", shell => shell.WithFeature<CleanupFeatureB>()));
+        services.AddSingleton<IShellGenerationActivationParticipant>(blocker);
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var shellA = await registry.ActivateAsync("cleanup-a");
+        var endpointReference = CaptureEndpointReference(dataSource, new ShellId("cleanup-a"));
+        var activateB = Task.Run(() => registry.ActivateAsync("cleanup-b"));
+
+        await blocker.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            var drain = await registry.DrainAsync(shellA);
+            await drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.DoesNotContain(dataSource.Endpoints, endpoint =>
+                endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(new ShellId("cleanup-a")) == true);
+            Assert.Contains(dataSource.Endpoints, endpoint =>
+                endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(new ShellId("cleanup-b")) == true);
+            await AssertReferenceCollectedAsync(endpointReference, "drained cleanup-a endpoint");
+        }
+        finally
+        {
+            blocker.Release();
+        }
+
+        await activateB.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact(DisplayName = "A pending candidate can drain and dispose without breaking rollback restoration")]
+    public async Task PendingCommit_SameShellCandidateDrain_RestoresPriorGenerationWithoutStaleRoutes()
+    {
+        var blocker = new BlockingActivationParticipant("cleanup-same", generation: 2, rejectAfterRelease: true);
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<CleanupFeatureA>()
+            .AddShell("cleanup-same", shell => shell.WithFeature<CleanupFeatureA>()));
+        services.AddSingleton<IShellGenerationActivationParticipant>(blocker);
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var generationOne = await registry.ActivateAsync("cleanup-same");
+        var reloadTask = Task.Run(() => registry.ReloadAsync("cleanup-same"));
+
+        await blocker.Entered.WaitAsync(TimeSpan.FromSeconds(5));
+        try
+        {
+            var candidate = registry.GetActive("cleanup-same")!;
+            Assert.Equal(2, candidate.Descriptor.Generation);
+            var drain = await registry.DrainAsync(candidate);
+            await drain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(ShellLifecycleState.Disposed, candidate.State);
+        }
+        finally
+        {
+            blocker.Release();
+        }
+
+        var reload = await reloadTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Same(generationOne, registry.GetActive("cleanup-same"));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        Assert.Single(dataSource.Endpoints);
+    }
+
     [Fact(DisplayName = "Repeated collectible feature generations unload after replacement and removal")]
     public async Task CollectibleFeatureGenerations_UnloadAfterReplacementAndRemoval()
     {
@@ -721,6 +804,26 @@ public class DynamicShellEndpointDataSourceTests
         Assert.False(loadContext.IsAlive,
             $"Collectible feature load context remained rooted after cycle {cycle}; " +
             "published or retired endpoint state still retains feature assembly code.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CaptureEndpointReference(
+        DynamicShellEndpointDataSource dataSource,
+        ShellId shellId) =>
+        new(dataSource.Endpoints.Single(endpoint =>
+            endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()?.ShellId.Equals(shellId) == true));
+
+    private static async Task AssertReferenceCollectedAsync(WeakReference reference, string description)
+    {
+        for (var attempt = 0; attempt < 100 && reference.IsAlive; attempt++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            await Task.Yield();
+        }
+
+        Assert.False(reference.IsAlive, $"The {description} remained rooted after lifecycle cleanup.");
     }
 
     private static void CaptureRoutingInfrastructure(IServiceProvider services)
@@ -971,4 +1074,62 @@ public sealed class RejectSecondGenerationCommitParticipant : IShellGenerationAc
     public void Rollback(IShell shell)
     {
     }
+}
+
+[ShellFeature("CleanupFeatureA")]
+public sealed class CleanupFeatureA : IWebShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+        endpoints.MapGet("/cleanup/a", () => Results.Ok());
+}
+
+[ShellFeature("CleanupFeatureB")]
+public sealed class CleanupFeatureB : IWebShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+        endpoints.MapGet("/cleanup/b", () => Results.Ok());
+}
+
+public sealed class BlockingActivationParticipant(
+    string shellName,
+    int generation,
+    bool rejectAfterRelease = false) : IShellGenerationActivationParticipant
+{
+    private readonly TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Entered => entered.Task;
+
+    public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+
+    public void Commit(IShell shell)
+    {
+        if (!string.Equals(shell.Descriptor.Name, shellName, StringComparison.OrdinalIgnoreCase)
+            || shell.Descriptor.Generation != generation)
+            return;
+
+        entered.TrySetResult();
+        release.Task.GetAwaiter().GetResult();
+        if (rejectAfterRelease)
+            throw new InvalidOperationException("blocked candidate rejected after cleanup");
+    }
+
+    public void Complete(IShell shell)
+    {
+    }
+
+    public void Rollback(IShell shell)
+    {
+    }
+
+    public void Release() => release.TrySetResult();
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/DynamicShellEndpointDataSourceTests.cs
@@ -1,9 +1,11 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
+using CShells.AspNetCore.Extensions;
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
 using CShells.AspNetCore.Notifications;
+using CShells.DependencyInjection;
 using CShells.AspNetCore.Features;
 using CShells.Features;
 using CShells.Lifecycle;
@@ -11,6 +13,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
@@ -137,6 +140,14 @@ public class DynamicShellEndpointDataSourceTests
 
         Assert.Contains("DynamicShell:FeatureV2", exception.Message);
         Assert.Contains("DynamicShell:FeatureV1", exception.Message);
+        Assert.Contains("shell 'other' generation 1", exception.Message);
+        Assert.Contains("shell 'default' generation 1", exception.Message);
+        Assert.Equal(conflictingShell, exception.Conflict.CandidateOwner.ShellId);
+        Assert.Equal(1, exception.Conflict.CandidateOwner.Generation);
+        Assert.Equal("FeatureV2", exception.Conflict.CandidateOwner.OwnerId);
+        Assert.Equal(shellId, exception.Conflict.ExistingOwner.ShellId);
+        Assert.Equal(1, exception.Conflict.ExistingOwner.Generation);
+        Assert.Equal("FeatureV1", exception.Conflict.ExistingOwner.OwnerId);
         var remaining = Assert.Single(dataSource.Endpoints);
         Assert.Equal("default", remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.ShellId.Name);
     }
@@ -157,6 +168,14 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Contains("DynamicShell:B", exception.Message);
         Assert.Contains("DynamicShell:A", exception.Message);
         Assert.Single(dataSource.Endpoints);
+    }
+
+    [Fact(DisplayName = "Method overlap compares HTTP methods case-insensitively")]
+    public void MethodsConflict_MethodCaseDiffers_ReturnsTrue()
+    {
+        // HttpMethodMetadata normalizes methods to upper case, so exercise the data source's
+        // comparison seam directly to keep its behavior correct for any non-normalized inventory.
+        Assert.True(DynamicShellEndpointDataSource.MethodsConflict(["GET"], ["get"]));
     }
 
     [Fact(DisplayName = "PublishGeneration rejects same-batch collisions before publication")]
@@ -191,6 +210,13 @@ public class DynamicShellEndpointDataSourceTests
 
         Assert.Contains("DynamicShell:Feature", exception.Message);
         Assert.Contains("Host:Host API", exception.Message);
+        Assert.Equal(shellId, exception.Conflict.CandidateOwner.ShellId);
+        Assert.Equal(1, exception.Conflict.CandidateOwner.Generation);
+        Assert.Equal("Feature", exception.Conflict.CandidateOwner.OwnerId);
+        Assert.Equal(EndpointOwnerKind.Host, exception.Conflict.ExistingOwner.OwnerKind);
+        Assert.Equal("Host API", exception.Conflict.ExistingOwner.OwnerId);
+        Assert.Null(exception.Conflict.ExistingOwner.ShellId);
+        Assert.Null(exception.Conflict.ExistingOwner.Generation);
         Assert.Empty(dataSource.Endpoints);
     }
 
@@ -202,7 +228,7 @@ public class DynamicShellEndpointDataSourceTests
         var settings = new ShellSettings();
         dataSource.PublishGeneration(shellId, 1, [CreateEndpoint("api/items", shellId, 1, settings, "FeatureV1")]);
 
-        IReadOnlyList<Endpoint>? observed = null;
+        var observed = (IReadOnlyList<Endpoint>?)null;
         using var registration = dataSource.GetChangeToken().RegisterChangeCallback(_ => observed = dataSource.Endpoints, null);
         dataSource.PublishGeneration(shellId, 2,
         [
@@ -238,6 +264,69 @@ public class DynamicShellEndpointDataSourceTests
         Assert.Throws<InvalidOperationException>(() => handler.RegisterActiveShell(shell));
         var remaining = Assert.Single(dataSource.Endpoints);
         Assert.Equal(1, remaining.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    [Fact(DisplayName = "Rejected reload restores the prior endpoint snapshot and keeps its pipeline live")]
+    public async Task Reload_LaterSubscriberRejectsCandidate_RestoresPriorGeneration()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell("rollback", shell => shell.WithFeature<RollbackStableFeature>()));
+        services.AddSingleton<IShellLifecycleSubscriber, RejectSecondGenerationSubscriber>();
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("rollback");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "stable");
+
+        var reload = await registry.ReloadAsync(shellId.Name);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.Same(generationOne, registry.GetActive(shellId.Name));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "stable");
+        Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
+    }
+
+    [Fact(DisplayName = "Middleware composition failure rejects a reload and preserves the prior generation")]
+    public async Task Reload_MiddlewareCompositionFails_PreservesPriorGeneration()
+    {
+        var attempts = new MiddlewareCompositionAttempts();
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton(attempts);
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<FailOnSecondCompositionFeature>()
+            .AddShell("composition", shell => shell.WithFeature<FailOnSecondCompositionFeature>()));
+
+        await using var host = services.BuildServiceProvider();
+        CaptureRoutingInfrastructure(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("composition");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "composition");
+
+        var reload = await registry.ReloadAsync(shellId.Name);
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.Same(generationOne, registry.GetActive(shellId.Name));
+        AssertGeneration(dataSource, expectedGeneration: 1);
+        await AssertPipelineMarkerAsync(pipelines, shellId, generation: 1, "composition");
+        Assert.Null(pipelines.Get(shellId, generation: 2, _ => Task.CompletedTask));
     }
 
     [Fact(DisplayName = "Repeated collectible feature generations unload after replacement and removal")]
@@ -339,6 +428,31 @@ public class DynamicShellEndpointDataSourceTests
             "published or retired endpoint state still retains feature assembly code.");
     }
 
+    private static void CaptureRoutingInfrastructure(IServiceProvider services)
+    {
+        services.GetRequiredService<EndpointRouteBuilderAccessor>().EndpointRouteBuilder = new TestEndpointRouteBuilder(services);
+        services.GetRequiredService<ApplicationBuilderAccessor>().ApplicationBuilder = new ApplicationBuilder(services);
+    }
+
+    private static void AssertGeneration(DynamicShellEndpointDataSource dataSource, int expectedGeneration)
+    {
+        var endpoint = Assert.Single(dataSource.Endpoints);
+        Assert.Equal(expectedGeneration, endpoint.Metadata.GetMetadata<ShellEndpointMetadata>()!.Generation);
+    }
+
+    private static async Task AssertPipelineMarkerAsync(
+        ShellMiddlewarePipelineRegistry pipelines,
+        ShellId shellId,
+        int generation,
+        string expectedMarker)
+    {
+        var pipeline = pipelines.Get(shellId, generation, _ => Task.CompletedTask);
+        Assert.NotNull(pipeline);
+        var context = new DefaultHttpContext();
+        await pipeline!(context);
+        Assert.Equal(expectedMarker, context.Items["pipeline-marker"]);
+    }
+
     private sealed class CollectibleFeatureLoadContext : AssemblyLoadContext
     {
         public CollectibleFeatureLoadContext()
@@ -427,4 +541,66 @@ public class DynamicShellEndpointDataSourceTests
         public ICollection<EndpointDataSource> DataSources { get; } = [];
         public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
     }
+}
+
+[ShellFeature("RollbackStable")]
+public sealed class RollbackStableFeature : IWebShellFeature, IMiddlewareShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+        endpoints.MapGet("/rollback", () => Results.Ok());
+
+    public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment) =>
+        app.Use(next => context =>
+        {
+            context.Items["pipeline-marker"] = "stable";
+            return next(context);
+        });
+}
+
+[ShellFeature("FailOnSecondComposition")]
+public sealed class FailOnSecondCompositionFeature(MiddlewareCompositionAttempts attempts) : IWebShellFeature, IMiddlewareShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+
+    public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+        endpoints.MapGet("/composition", () => Results.Ok());
+
+    public void UseMiddleware(IApplicationBuilder app, IHostEnvironment? environment)
+    {
+        if (attempts.Increment() == 2)
+            throw new InvalidOperationException("second generation middleware composition failed");
+
+        app.Use(next => context =>
+        {
+            context.Items["pipeline-marker"] = "composition";
+            return next(context);
+        });
+    }
+}
+
+public sealed class MiddlewareCompositionAttempts
+{
+    private int attempts;
+
+    public int Increment() => Interlocked.Increment(ref attempts);
+}
+
+public sealed class RejectSecondGenerationSubscriber : IShellLifecycleSubscriber
+{
+    public Task OnStateChangedAsync(
+        IShell shell,
+        ShellLifecycleState previous,
+        ShellLifecycleState current,
+        CancellationToken cancellationToken = default) =>
+        current == ShellLifecycleState.Active && shell.Descriptor.Generation == 2
+            ? throw new ShellGenerationActivationException(
+                shell.Descriptor,
+                new InvalidOperationException("later subscriber rejected generation two"))
+            : Task.CompletedTask;
 }

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
@@ -41,7 +41,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
 
         Assert.NotNull(GetPipeline("acme", 1));
     }
@@ -56,7 +56,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
             _ => pipelineVisibleAtEndpointPublication = GetPipeline("acme", 1) is not null,
             null);
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
 
         Assert.True(pipelineVisibleAtEndpointPublication);
         Assert.Single(_endpoints.Endpoints);
@@ -69,7 +69,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
             ("ConflictingEndpointAndMiddleware", typeof(ConflictingEndpointAndMiddlewareFeature)));
 
         await Assert.ThrowsAsync<ShellGenerationActivationException>(() =>
-            _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active));
+            ActivateAsync(shell));
 
         Assert.Null(GetPipeline("acme", 1));
         Assert.Empty(_endpoints.Endpoints);
@@ -80,7 +80,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: null);
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
 
         Assert.Null(GetPipeline("acme", 1));
     }
@@ -94,7 +94,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
             ("Default", typeof(DefaultOrderFeature)), // no override → 0
             ("Early", typeof(EarlyFeature)));     // Order -10
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1);
 
         Assert.Equal(["early", "default", "late"], run.Markers);
@@ -108,7 +108,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
             ("Alpha", typeof(AlphaFeature)),
             ("Bravo", typeof(BravoFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1);
 
         Assert.Equal(["alpha", "bravo"], run.Markers);
@@ -118,7 +118,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     public async Task TeardownTransitions_RemovePipelineOnlyOnDisposed()
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
 
         await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Active, ShellLifecycleState.Deactivating);
         Assert.NotNull(GetPipeline("acme", 1));
@@ -136,9 +136,9 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         var gen1 = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
         var gen2 = CreateShell("acme", generation: 2, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
 
-        await _handler.OnStateChangedAsync(gen1, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(gen1);
         // ReloadAsync activates the new generation before deactivating the old one.
-        await _handler.OnStateChangedAsync(gen2, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(gen2);
         await _handler.OnStateChangedAsync(gen1, ShellLifecycleState.Draining, ShellLifecycleState.Disposed);
 
         Assert.Null(GetPipeline("acme", 1));
@@ -150,7 +150,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("PathCapture", typeof(PathCaptureFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1, path: "/acme/orders");
 
         Assert.Equal("/orders", run.FeaturePath);
@@ -165,7 +165,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("Rewrite", typeof(PathRewriteFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1, path: "/acme/orders");
 
         // The feature rewrote "/orders" → "/rewritten/orders"; the terminal re-applies the
@@ -179,7 +179,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Rewrite", typeof(PathRewriteFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1, path: "/orders");
 
         Assert.True(run.ContinuationCalled);
@@ -191,7 +191,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: "/acme", ("PathCapture", typeof(PathCaptureFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1, path: "/other");
 
         Assert.Null(run.FeaturePath);
@@ -204,7 +204,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: "/", ("Alpha", typeof(AlphaFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         var run = await InvokePipelineAsync("acme", 1, path: "/anything");
 
         Assert.Equal(["alpha"], run.Markers);
@@ -217,7 +217,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Broken", typeof(ThrowingFeature)));
 
         var exception = await Assert.ThrowsAsync<ShellGenerationActivationException>(() =>
-            _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active));
+            ActivateAsync(shell));
 
         Assert.IsType<InvalidOperationException>(exception.InnerException);
         Assert.Null(GetPipeline("acme", 1));
@@ -229,7 +229,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         _appBuilderAccessor.ApplicationBuilder = null;
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
 
         Assert.Null(GetPipeline("acme", 1));
     }
@@ -241,7 +241,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         _appBuilderAccessor.ApplicationBuilder = null;
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Alpha", typeof(AlphaFeature)));
 
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        await ActivateAsync(shell);
         Assert.Null(GetPipeline("acme", 1));
 
         // MapShells captures the builder and replays registration for active shells.
@@ -254,6 +254,13 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     // =================================================================
     // Helpers + test doubles
     // =================================================================
+
+    private async Task ActivateAsync(IShell shell)
+    {
+        await _handler.PrepareAsync(shell);
+        _handler.Commit(shell);
+        _handler.Complete(shell);
+    }
 
     private RequestDelegate? GetPipeline(string name, int generation) =>
         _pipelines.Get(new ShellId(name), generation, _ => Task.CompletedTask);

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellEndpointRegistrationHandlerMiddlewareTests.cs
@@ -20,6 +20,7 @@ namespace CShells.Tests.Integration.AspNetCore;
 public class ShellEndpointRegistrationHandlerMiddlewareTests
 {
     private readonly ShellMiddlewarePipelineRegistry _pipelines = new();
+    private readonly DynamicShellEndpointDataSource _endpoints = new();
     private readonly ApplicationBuilderAccessor _appBuilderAccessor;
     private readonly ShellEndpointRegistrationHandler _handler;
 
@@ -28,7 +29,7 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         var rootProvider = new ServiceCollection().BuildServiceProvider();
         _appBuilderAccessor = new ApplicationBuilderAccessor { ApplicationBuilder = new ApplicationBuilder(rootProvider) };
         _handler = new ShellEndpointRegistrationHandler(
-            new DynamicShellEndpointDataSource(),
+            _endpoints,
             new ActivatorFeatureFactory(),
             new EndpointRouteBuilderAccessor { EndpointRouteBuilder = new FakeEndpointRouteBuilder(rootProvider) },
             _appBuilderAccessor,
@@ -43,6 +44,35 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
 
         Assert.NotNull(GetPipeline("acme", 1));
+    }
+
+    [Fact(DisplayName = "The generation pipeline is available when its endpoint snapshot becomes visible")]
+    public async Task ActiveTransition_PublishesPipelineBeforeEndpointsBecomeVisible()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null,
+            ("EndpointAndMiddleware", typeof(EndpointAndMiddlewareFeature)));
+        var pipelineVisibleAtEndpointPublication = false;
+        using var registration = _endpoints.GetChangeToken().RegisterChangeCallback(
+            _ => pipelineVisibleAtEndpointPublication = GetPipeline("acme", 1) is not null,
+            null);
+
+        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+
+        Assert.True(pipelineVisibleAtEndpointPublication);
+        Assert.Single(_endpoints.Endpoints);
+    }
+
+    [Fact(DisplayName = "Rejected endpoint publication removes its staged generation pipeline")]
+    public async Task ActiveTransition_EndpointConflict_RemovesStagedPipeline()
+    {
+        var shell = CreateShell("acme", generation: 1, pathPrefix: null,
+            ("ConflictingEndpointAndMiddleware", typeof(ConflictingEndpointAndMiddlewareFeature)));
+
+        await Assert.ThrowsAsync<ShellGenerationActivationException>(() =>
+            _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active));
+
+        Assert.Null(GetPipeline("acme", 1));
+        Assert.Empty(_endpoints.Endpoints);
     }
 
     [Fact(DisplayName = "Initializing → Active without middleware features registers no pipeline")]
@@ -181,24 +211,16 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
         Assert.True(run.ContinuationCalled);
     }
 
-    [Fact(DisplayName = "A middleware feature that fails to compose registers a fail-closed 503 pipeline instead of going dark")]
-    public async Task CompositionFailure_RegistersFailClosed503Pipeline()
+    [Fact(DisplayName = "A middleware feature that fails to compose rejects activation and publishes no pipeline")]
+    public async Task CompositionFailure_RejectsActivationWithoutPipeline()
     {
         var shell = CreateShell("acme", generation: 1, pathPrefix: null, ("Broken", typeof(ThrowingFeature)));
 
-        // Must not throw: the lifecycle fan-out would swallow it and leave the shell dark.
-        await _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active);
+        var exception = await Assert.ThrowsAsync<ShellGenerationActivationException>(() =>
+            _handler.OnStateChangedAsync(shell, ShellLifecycleState.Initializing, ShellLifecycleState.Active));
 
-        // Bind the tracking continuation on the FIRST Get — binding is first-wins.
-        var continuationCalled = false;
-        var pipeline = _pipelines.Get(new ShellId("acme"), 1, _ => { continuationCalled = true; return Task.CompletedTask; });
-        Assert.NotNull(pipeline);
-
-        var ctx = new DefaultHttpContext();
-        await pipeline!(ctx);
-
-        Assert.Equal(StatusCodes.Status503ServiceUnavailable, ctx.Response.StatusCode);
-        Assert.False(continuationCalled);
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Null(GetPipeline("acme", 1));
     }
 
     [Fact(DisplayName = "Without a captured IApplicationBuilder no pipeline is registered and no exception is thrown")]
@@ -309,6 +331,23 @@ public class ShellEndpointRegistrationHandlerMiddlewareTests
     private sealed class AlphaFeature() : MarkerFeature("alpha", 0);
 
     private sealed class BravoFeature() : MarkerFeature("bravo", 0);
+
+    private sealed class EndpointAndMiddlewareFeature()
+        : MarkerFeature("endpoint-and-middleware", 0), IWebShellFeature
+    {
+        public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment) =>
+            endpoints.MapGet("/atomic-pipeline", () => Results.Ok());
+    }
+
+    private sealed class ConflictingEndpointAndMiddlewareFeature()
+        : MarkerFeature("conflicting-endpoint-and-middleware", 0), IWebShellFeature
+    {
+        public void MapEndpoints(IEndpointRouteBuilder endpoints, IHostEnvironment? environment)
+        {
+            foreach (var parameterName in new[] { "id", "name" })
+                endpoints.MapGet($"/collision/{{{parameterName}}}", () => Results.Ok());
+        }
+    }
 
     /// <summary>Does not override <see cref="IMiddlewareShellFeature.Order"/> — exercises the interface default of 0.</summary>
     private sealed class DefaultOrderFeature : IMiddlewareShellFeature

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -1,12 +1,17 @@
+using CShells.AspNetCore.Extensions;
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
+using CShells.DependencyInjection;
 using CShells.Lifecycle;
+using CShells.Lifecycle.Policies;
 using CShells.Resolution;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -178,6 +183,58 @@ public class ShellMiddlewareLazyActivationTests
         Assert.False(fallbackInvoked);
     }
 
+    [Fact(DisplayName = "Cold re-match leases the generation before exposing its endpoint to a concurrent reload")]
+    public async Task ColdStart_ReMatch_ConcurrentReload_KeepsMatchedGenerationLeased()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblyContaining<RollbackStableFeature>()
+            .AddShell("cold-race", shell => shell.WithFeature<RollbackStableFeature>())
+            .ConfigureDrainPolicy(new FixedTimeoutDrainPolicy(TimeSpan.FromSeconds(5))));
+
+        await using var host = services.BuildServiceProvider();
+        host.GetRequiredService<EndpointRouteBuilderAccessor>().EndpointRouteBuilder =
+            new TestEndpointRouteBuilder(host);
+        host.GetRequiredService<ApplicationBuilderAccessor>().ApplicationBuilder =
+            new ApplicationBuilder(host);
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var response = new ShellMiddlewareTests.FireableResponseFeature();
+        var endpointFeature = new BlockingShellEndpointFeature();
+        var context = new DefaultHttpContext();
+        context.Features.Set<IHttpResponseFeature>(response);
+        context.Features.Set<IEndpointFeature>(endpointFeature);
+        context.Request.Method = "GET";
+        context.Request.Path = "/rollback";
+        var endpointInvoked = false;
+        var middleware = CreateMiddleware(
+            _ =>
+            {
+                endpointInvoked = true;
+                return Task.CompletedTask;
+            },
+            new FixedShellResolver("cold-race"),
+            registry,
+            host.GetRequiredService<DynamicShellEndpointDataSource>());
+
+        var request = Task.Run(() => middleware.InvokeAsync(context));
+        await endpointFeature.ShellEndpointAssigned.WaitAsync(TimeSpan.FromSeconds(5));
+        var generationOne = registry.GetActive("cold-race")!;
+        var reload = await registry.ReloadAsync("cold-race");
+
+        Assert.NotNull(reload.Drain);
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
+        Assert.Equal(1, ((Shell)generationOne).ActiveScopeCount);
+
+        endpointFeature.Release();
+        await request;
+        Assert.True(endpointInvoked);
+        await response.FireOnCompletedAsync();
+        await reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+    }
+
     [Fact(DisplayName = "Cold-start re-match preserves fallback endpoint when no shell endpoint matches")]
     public async Task ColdStart_ReMatch_PreservesFallbackEndpoint_WhenNoShellEndpointMatches()
     {
@@ -285,6 +342,38 @@ public class ShellMiddlewareLazyActivationTests
     {
         public Task<ShellId?> ResolveAsync(ShellResolutionContext context, CancellationToken cancellationToken = default) =>
             Task.FromResult<ShellId?>(new ShellId(name));
+    }
+
+    private sealed class BlockingShellEndpointFeature : IEndpointFeature
+    {
+        private readonly TaskCompletionSource assigned = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Endpoint? endpoint;
+
+        public Task ShellEndpointAssigned => assigned.Task;
+
+        public Endpoint? Endpoint
+        {
+            get => endpoint;
+            set
+            {
+                endpoint = value;
+                if (value?.Metadata.GetMetadata<ShellEndpointMetadata>() is null)
+                    return;
+
+                assigned.TrySetResult();
+                release.Task.GetAwaiter().GetResult();
+            }
+        }
+
+        public void Release() => release.TrySetResult();
+    }
+
+    private sealed class TestEndpointRouteBuilder(IServiceProvider serviceProvider) : IEndpointRouteBuilder
+    {
+        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
     }
 
     /// <summary>

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareLazyActivationTests.cs
@@ -219,20 +219,36 @@ public class ShellMiddlewareLazyActivationTests
 
         var request = Task.Run(() => middleware.InvokeAsync(context));
         await endpointFeature.ShellEndpointAssigned.WaitAsync(TimeSpan.FromSeconds(5));
-        var generationOne = registry.GetActive("cold-race")!;
-        var reload = await registry.ReloadAsync("cold-race");
+        try
+        {
+            var generationOne = registry.GetActive("cold-race")!;
+            var reload = await registry.ReloadAsync("cold-race");
 
-        Assert.NotNull(reload.Drain);
-        await Assert.ThrowsAsync<TimeoutException>(() =>
-            reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
-        Assert.Equal(1, ((Shell)generationOne).ActiveScopeCount);
+            Assert.NotNull(reload.Drain);
+            await Assert.ThrowsAsync<TimeoutException>(() =>
+                reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
+            Assert.Equal(1, ((Shell)generationOne).ActiveScopeCount);
 
-        endpointFeature.Release();
-        await request;
-        Assert.True(endpointInvoked);
-        await response.FireOnCompletedAsync();
-        await reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+            endpointFeature.Release();
+            await request;
+            Assert.True(endpointInvoked);
+            await response.FireOnCompletedAsync();
+            await reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+        }
+        finally
+        {
+            endpointFeature.Release();
+            try
+            {
+                await request.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+                // Preserve the primary assertion failure while ensuring the blocked worker exits.
+            }
+            await response.FireOnCompletedAsync();
+        }
     }
 
     [Fact(DisplayName = "Cold-start re-match preserves fallback endpoint when no shell endpoint matches")]

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -4,6 +4,8 @@ using CShells.Lifecycle;
 using CShells.Resolution;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -165,6 +167,49 @@ public class ShellMiddlewareTests
         Assert.NotNull(servicesInsidePipeline?.GetService<ITestService>()); // shell scope was already set
     }
 
+    [Fact(DisplayName = "InvokeAsync binds a matched endpoint to its exact generation after reload")]
+    public async Task InvokeAsync_MatchedOlderGeneration_UsesExactGeneration()
+    {
+        var generationOne = FakeShell.WithServices(_ => { }, name: "TestShell", generation: 1);
+        var generationTwo = FakeShell.WithServices(_ => { }, name: "TestShell", generation: 2);
+        var pipelineRegistry = new ShellMiddlewarePipelineRegistry();
+        var generationOneInvoked = false;
+        var generationTwoInvoked = false;
+
+        pipelineRegistry.Set(new ShellId("TestShell"), 1, context =>
+        {
+            generationOneInvoked = true;
+            return Task.CompletedTask;
+        }, new ShellPipelineContinuation());
+        pipelineRegistry.Set(new ShellId("TestShell"), 2, context =>
+        {
+            generationTwoInvoked = true;
+            return Task.CompletedTask;
+        }, new ShellPipelineContinuation());
+
+        var middleware = CreateMiddleware(
+            _ => Task.CompletedTask,
+            resolver: new FixedShellResolver("TestShell"),
+            registry: new FakeRegistry(generationOne, generationTwo),
+            pipelineRegistry: pipelineRegistry);
+
+        var (httpContext, _) = CreateHttpContextWithFireableResponse();
+        var settings = new ShellSettings(new ShellId("TestShell"));
+        var endpoint = new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("api/items"),
+            order: 0,
+            new EndpointMetadataCollection(
+                new ShellEndpointMetadata(new ShellId("TestShell"), 1, settings)),
+            "generation-one");
+        httpContext.SetEndpoint(endpoint);
+
+        await middleware.InvokeAsync(httpContext);
+
+        Assert.True(generationOneInvoked);
+        Assert.False(generationTwoInvoked);
+    }
+
     [Fact(DisplayName = "Another shell's pipeline is not invoked for the resolved shell")]
     public async Task InvokeAsync_PipelineForDifferentShell_FallsBackToNext()
     {
@@ -292,9 +337,9 @@ public class ShellMiddlewareTests
             Task.FromResult<ShellId?>(shellId);
     }
 
-    internal sealed class FakeRegistry(FakeShell? shell = null) : IShellRegistry
+    internal sealed class FakeRegistry(params FakeShell[] shells) : IShellRegistry
     {
-        private readonly FakeShell? _shell = shell;
+        private readonly FakeShell[] _shells = shells;
 
         public Task<IShell> GetOrActivateAsync(string name, CancellationToken ct = default)
             => GetActive(name) is { } active
@@ -309,9 +354,13 @@ public class ShellMiddlewareTests
         public Task<IShellBlueprintManager?> GetManagerAsync(string name, CancellationToken ct = default) => Task.FromResult<IShellBlueprintManager?>(null);
         public Task<ShellPage> ListAsync(ShellListQuery query, CancellationToken ct = default) => Task.FromResult(new ShellPage([], null));
         public IShell? GetActive(string name)
-            => _shell is not null && string.Equals(_shell.Descriptor.Name, name, StringComparison.OrdinalIgnoreCase) ? _shell : null;
-        public IReadOnlyCollection<IShell> GetAll(string name) => _shell is null ? [] : [_shell];
-        public IReadOnlyCollection<IShell> GetActiveShells() => _shell is null ? [] : [_shell];
+            => _shells
+                .Where(shell => string.Equals(shell.Descriptor.Name, name, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(shell => shell.Descriptor.Generation)
+                .FirstOrDefault();
+        public IReadOnlyCollection<IShell> GetAll(string name) =>
+            _shells.Where(shell => string.Equals(shell.Descriptor.Name, name, StringComparison.OrdinalIgnoreCase)).ToArray();
+        public IReadOnlyCollection<IShell> GetActiveShells() => _shells;
         public void Subscribe(IShellLifecycleSubscriber subscriber) { }
         public void Unsubscribe(IShellLifecycleSubscriber subscriber) { }
     }
@@ -333,11 +382,11 @@ public class ShellMiddlewareTests
             return new FakeScope(this, scope);
         }
 
-        public static FakeShell WithServices(Action<IServiceCollection> configure, string name = "TestShell")
+        public static FakeShell WithServices(Action<IServiceCollection> configure, string name = "TestShell", int generation = 1)
         {
             var services = new ServiceCollection();
             configure(services);
-            return new FakeShell(ShellDescriptor.Create(name, 1), services.BuildServiceProvider());
+            return new FakeShell(ShellDescriptor.Create(name, generation), services.BuildServiceProvider());
         }
 
         private sealed class FakeScope(FakeShell owner, AsyncServiceScope inner) : IShellScope

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -237,7 +237,6 @@ public class ShellMiddlewareTests
             generationOne.Descriptor.Generation,
             [CreateEndpoint("/payments/old", shellId, generationOne.Descriptor.Generation, settings, "GenerationOne")]);
         var oldEndpoint = endpointDataSource.Endpoints.Single();
-        var guardScope = generationOne.BeginScope();
 
         var oldRequestEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseOldRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -265,6 +264,12 @@ public class ShellMiddlewareTests
         oldContext.Features.Set<IHttpResponseFeature>(oldResponse);
         oldContext.SetEndpoint(oldEndpoint);
 
+        // Enter middleware before reload so this request's own generation-one scope is the
+        // in-flight work that the real drain operation must wait for.
+        var oldRequest = middleware.InvokeAsync(oldContext);
+        await oldRequestEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(oldPipelineInvoked);
+
         var reload = await registry.ReloadAsync(shellId.Name);
         Assert.Null(reload.Error);
         Assert.NotNull(reload.NewShell);
@@ -289,12 +294,6 @@ public class ShellMiddlewareTests
             },
             new ShellPipelineContinuation());
 
-        // Start the old matched request only after reload has promoted generation two. Its
-        // endpoint metadata must still select generation one's draining shell and pipeline.
-        var oldRequest = middleware.InvokeAsync(oldContext);
-        await oldRequestEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(oldPipelineInvoked);
-
         var newResponse = new FireableResponseFeature();
         var newContext = new DefaultHttpContext();
         newContext.Features.Set<IHttpResponseFeature>(newResponse);
@@ -310,7 +309,6 @@ public class ShellMiddlewareTests
         await Assert.ThrowsAsync<TimeoutException>(() => oldDrain.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
 
         await oldResponse.FireOnCompletedAsync();
-        await guardScope.DisposeAsync();
         await oldDrain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -1,7 +1,11 @@
 using CShells.AspNetCore.Middleware;
 using CShells.AspNetCore.Routing;
+using CShells.AspNetCore.Extensions;
+using CShells.DependencyInjection;
 using CShells.Lifecycle;
+using CShells.Lifecycle.Policies;
 using CShells.Resolution;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
@@ -210,6 +214,115 @@ public class ShellMiddlewareTests
         Assert.False(generationTwoInvoked);
     }
 
+    [Fact(DisplayName = "Reload drain holds an old matched request while replacement requests use the new generation")]
+    public async Task InvokeAsync_ReloadDrain_BindsInFlightRequestAndWaitsForCompletion()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblies()
+            .AddShell("payments", _ => { })
+            .ConfigureDrainPolicy(new FixedTimeoutDrainPolicy(TimeSpan.FromSeconds(5))));
+
+        await using var host = services.BuildServiceProvider();
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var endpointDataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelineRegistry = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var shellId = new ShellId("payments");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+        var settings = new ShellSettings(shellId);
+
+        endpointDataSource.PublishGeneration(
+            shellId,
+            generationOne.Descriptor.Generation,
+            [CreateEndpoint("/payments/old", shellId, generationOne.Descriptor.Generation, settings, "GenerationOne")]);
+        var oldEndpoint = endpointDataSource.Endpoints.Single();
+        var guardScope = generationOne.BeginScope();
+
+        var oldRequestEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOldRequest = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var oldPipelineInvoked = false;
+        pipelineRegistry.Set(
+            shellId,
+            generationOne.Descriptor.Generation,
+            async _ =>
+            {
+                oldPipelineInvoked = true;
+                oldRequestEntered.SetResult();
+                await releaseOldRequest.Task;
+            },
+            new ShellPipelineContinuation());
+
+        var middleware = CreateMiddleware(
+            _ => Task.CompletedTask,
+            resolver: new FixedShellResolver(shellId),
+            registry: registry,
+            endpointDataSource: endpointDataSource,
+            pipelineRegistry: pipelineRegistry);
+
+        var oldResponse = new FireableResponseFeature();
+        var oldContext = new DefaultHttpContext();
+        oldContext.Features.Set<IHttpResponseFeature>(oldResponse);
+        oldContext.SetEndpoint(oldEndpoint);
+
+        var reload = await registry.ReloadAsync(shellId.Name);
+        Assert.Null(reload.Error);
+        Assert.NotNull(reload.NewShell);
+        Assert.NotNull(reload.Drain);
+        var generationTwo = reload.NewShell!;
+        var oldDrain = reload.Drain!;
+        Assert.Same(generationTwo, registry.GetActive(shellId.Name));
+
+        endpointDataSource.PublishGeneration(
+            shellId,
+            generationTwo.Descriptor.Generation,
+            [CreateEndpoint("/payments/new", shellId, generationTwo.Descriptor.Generation, settings, "GenerationTwo")]);
+
+        var newRequestInvoked = false;
+        pipelineRegistry.Set(
+            shellId,
+            generationTwo.Descriptor.Generation,
+            _ =>
+            {
+                newRequestInvoked = true;
+                return Task.CompletedTask;
+            },
+            new ShellPipelineContinuation());
+
+        // Start the old matched request only after reload has promoted generation two. Its
+        // endpoint metadata must still select generation one's draining shell and pipeline.
+        var oldRequest = middleware.InvokeAsync(oldContext);
+        await oldRequestEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(oldPipelineInvoked);
+
+        var newResponse = new FireableResponseFeature();
+        var newContext = new DefaultHttpContext();
+        newContext.Features.Set<IHttpResponseFeature>(newResponse);
+        newContext.SetEndpoint(endpointDataSource.Endpoints.Single());
+
+        await middleware.InvokeAsync(newContext);
+        Assert.True(newRequestInvoked, "The replacement request must use generation two's pipeline.");
+        await newResponse.FireOnCompletedAsync();
+
+        // The old pipeline has returned, but its scope is deliberately retained by OnCompleted.
+        releaseOldRequest.SetResult();
+        await oldRequest;
+        await Assert.ThrowsAsync<TimeoutException>(() => oldDrain.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        await oldResponse.FireOnCompletedAsync();
+        await guardScope.DisposeAsync();
+        await oldDrain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+        Assert.Equal(generationTwo.Descriptor.Generation, endpointDataSource.Endpoints
+            .Single()
+            .Metadata.GetMetadata<ShellEndpointMetadata>()!
+            .Generation);
+
+        var replacementDrain = await registry.DrainAsync(generationTwo);
+        await replacementDrain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     [Fact(DisplayName = "Another shell's pipeline is not invoked for the resolved shell")]
     public async Task InvokeAsync_PipelineForDifferentShell_FallsBackToNext()
     {
@@ -309,6 +422,22 @@ public class ShellMiddlewareTests
             pipelineRegistry ?? new ShellMiddlewarePipelineRegistry(),
             cache ?? new MemoryCache(new MemoryCacheOptions()),
             options ?? Options.Create(new ShellMiddlewareOptions()));
+
+    private static RouteEndpoint CreateEndpoint(
+        string pattern,
+        ShellId shellId,
+        int generation,
+        ShellSettings settings,
+        string featureName) =>
+        new(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(pattern),
+            order: 0,
+            new EndpointMetadataCollection(
+                new ShellEndpointMetadata(shellId, generation, settings, featureName),
+                new EndpointOwnershipMetadata(EndpointOwnerKind.DynamicShell, featureName, shellId, generation),
+                new HttpMethodMetadata(["GET"])),
+            displayName: $"{pattern} (generation {generation})");
 
     private static (DefaultHttpContext Context, FireableResponseFeature Response) CreateHttpContextWithFireableResponse(
         IServiceProvider? requestServices = null)

--- a/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
+++ b/tests/CShells.Tests/Integration/AspNetCore/ShellMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -319,6 +320,96 @@ public class ShellMiddlewareTests
 
         var replacementDrain = await registry.DrainAsync(generationTwo);
         await replacementDrain.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact(DisplayName = "A request matched before reload keeps the exact generation leased until response completion")]
+    public async Task InvokeAsync_MatchedBeforeReload_UsesRoutingLeaseAcrossMiddlewareGap()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddCShellsAspNetCore(cshells => cshells
+            .WithAssemblies()
+            .AddShell("leased", _ => { })
+            .ConfigureDrainPolicy(new FixedTimeoutDrainPolicy(TimeSpan.FromSeconds(5))));
+
+        await using var host = services.BuildServiceProvider();
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var dataSource = host.GetRequiredService<DynamicShellEndpointDataSource>();
+        var pipelines = host.GetRequiredService<ShellMiddlewarePipelineRegistry>();
+        var policy = host.GetServices<MatcherPolicy>().OfType<ShellEndpointGenerationMatcherPolicy>().Single();
+        var shellId = new ShellId("leased");
+        var generationOne = await registry.ActivateAsync(shellId.Name);
+        var settings = new ShellSettings(shellId);
+        dataSource.PublishGeneration(
+            shellId,
+            generationOne.Descriptor.Generation,
+            [CreateEndpoint("/leased/old", shellId, generationOne.Descriptor.Generation, settings, "GenerationOne")]);
+        var oldEndpoint = dataSource.Endpoints.Single();
+        var oldPipelineInvoked = false;
+        pipelines.Set(
+            shellId,
+            generationOne.Descriptor.Generation,
+            _ =>
+            {
+                oldPipelineInvoked = true;
+                return Task.CompletedTask;
+            },
+            new ShellPipelineContinuation());
+        var response = new FireableResponseFeature();
+        var context = new DefaultHttpContext();
+        context.Features.Set<IHttpResponseFeature>(response);
+        var candidates = new CandidateSet([oldEndpoint], [new RouteValueDictionary()], [0]);
+
+        await policy.ApplyAsync(context, candidates);
+        await policy.ApplyAsync(context, candidates);
+        context.SetEndpoint(oldEndpoint);
+
+        Assert.Equal(int.MaxValue, policy.Order);
+        Assert.Equal(1, ((Shell)generationOne).ActiveScopeCount);
+        var reload = await registry.ReloadAsync(shellId.Name);
+        Assert.NotNull(reload.Drain);
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        var middleware = CreateMiddleware(
+            _ => Task.CompletedTask,
+            registry: registry,
+            endpointDataSource: dataSource,
+            pipelineRegistry: pipelines);
+        await middleware.InvokeAsync(context);
+
+        Assert.True(oldPipelineInvoked);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(100)));
+
+        await response.FireOnCompletedAsync();
+        await reload.Drain!.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(ShellLifecycleState.Disposed, generationOne.State);
+    }
+
+    [Fact(DisplayName = "Routing lease acquisition is idempotent and releases when middleware is short-circuited")]
+    public async Task MatcherPolicy_ReenteredThenShortCircuited_ReleasesSingleScopeOnCompletion()
+    {
+        var shell = FakeShell.WithServices(_ => { }, name: "leased", generation: 1);
+        var policy = new ShellEndpointGenerationMatcherPolicy(new FakeRegistry(shell));
+        var endpoint = CreateEndpoint(
+            "/leased",
+            new ShellId("leased"),
+            generation: 1,
+            new ShellSettings(new ShellId("leased")),
+            "LeasedFeature");
+        var response = new FireableResponseFeature();
+        var context = new DefaultHttpContext();
+        context.Features.Set<IHttpResponseFeature>(response);
+        var candidates = new CandidateSet([endpoint], [new RouteValueDictionary()], [0]);
+
+        await policy.ApplyAsync(context, candidates);
+        await policy.ApplyAsync(context, candidates);
+
+        Assert.Equal(1, shell.ActiveScopeCount);
+        await response.FireOnCompletedAsync();
+        Assert.Equal(0, shell.ActiveScopeCount);
     }
 
     [Fact(DisplayName = "Another shell's pipeline is not invoked for the resolved shell")]

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -79,6 +79,22 @@ public class ShellRegistryActivateTests
         Assert.Empty(registry.GetAll("payments"));
     }
 
+    [Fact(DisplayName = "Endpoint publication failure aborts the candidate generation and preserves no partial entry")]
+    public async Task GenerationPublicationFailure_DisposesCandidate_NoPartialEntry()
+    {
+        await using var host = BuildHost(
+            cshells => cshells
+                .WithAssemblies()
+                .AddShell("payments", _ => { }),
+            services => services.AddSingleton<IShellLifecycleSubscriber, RejectingActivationSubscriber>());
+        var registry = host.GetRequiredService<IShellRegistry>();
+
+        await Assert.ThrowsAsync<ShellGenerationActivationException>(() => registry.ActivateAsync("payments"));
+
+        Assert.Null(registry.GetActive("payments"));
+        Assert.Empty(registry.GetAll("payments"));
+    }
+
     [Fact(DisplayName = "Blueprint name mismatch in composed settings throws")]
     public async Task Blueprint_NameMismatch_Throws()
     {
@@ -184,6 +200,18 @@ public class ShellRegistryActivateTests
             public static readonly NullScope Instance = new();
             public void Dispose() { }
         }
+    }
+
+    private sealed class RejectingActivationSubscriber : IShellLifecycleSubscriber
+    {
+        public Task OnStateChangedAsync(
+            IShell shell,
+            ShellLifecycleState previous,
+            ShellLifecycleState current,
+            CancellationToken cancellationToken = default) =>
+            current == ShellLifecycleState.Active
+                ? throw new ShellGenerationActivationException(shell.Descriptor, new InvalidOperationException("candidate rejected"))
+                : Task.CompletedTask;
     }
 }
 

--- a/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
+++ b/tests/CShells.Tests/Integration/Lifecycle/ShellRegistryActivateTests.cs
@@ -95,6 +95,36 @@ public class ShellRegistryActivateTests
         Assert.Empty(registry.GetAll("payments"));
     }
 
+    [Fact(DisplayName = "A later participant commit failure rolls every participant back in reverse order")]
+    public async Task Reload_ParticipantCommitFailure_RestoresPriorRegistryStateAndRollsBackInReverse()
+    {
+        var events = new List<string>();
+        var first = new RecordingActivationParticipant("first", events);
+        var second = new RecordingActivationParticipant("second", events, failCommitGeneration: 2);
+        await using var host = BuildHost(
+            cshells => cshells
+                .WithAssemblies()
+                .AddShell("payments", _ => { }),
+            services =>
+            {
+                services.AddSingleton<IShellGenerationActivationParticipant>(first);
+                services.AddSingleton<IShellGenerationActivationParticipant>(second);
+            });
+        var registry = host.GetRequiredService<IShellRegistry>();
+        var generationOne = await registry.ActivateAsync("payments");
+        events.Clear();
+
+        var reload = await registry.ReloadAsync("payments");
+
+        Assert.IsType<ShellGenerationActivationException>(reload.Error);
+        Assert.Null(reload.NewShell);
+        Assert.Same(generationOne, registry.GetActive("payments"));
+        Assert.Equal([generationOne], registry.GetAll("payments"));
+        Assert.Equal(
+            ["prepare:first", "prepare:second", "commit:first", "commit:second", "rollback:second", "rollback:first"],
+            events);
+    }
+
     [Fact(DisplayName = "Blueprint name mismatch in composed settings throws")]
     public async Task Blueprint_NameMismatch_Throws()
     {
@@ -212,6 +242,29 @@ public class ShellRegistryActivateTests
             current == ShellLifecycleState.Active
                 ? throw new ShellGenerationActivationException(shell.Descriptor, new InvalidOperationException("candidate rejected"))
                 : Task.CompletedTask;
+    }
+
+    private sealed class RecordingActivationParticipant(
+        string name,
+        List<string> events,
+        int? failCommitGeneration = null) : IShellGenerationActivationParticipant
+    {
+        public Task PrepareAsync(IShell shell, CancellationToken cancellationToken = default)
+        {
+            events.Add($"prepare:{name}");
+            return Task.CompletedTask;
+        }
+
+        public void Commit(IShell shell)
+        {
+            events.Add($"commit:{name}");
+            if (shell.Descriptor.Generation == failCommitGeneration)
+                throw new InvalidOperationException($"{name} rejected commit");
+        }
+
+        public void Complete(IShell shell) => events.Add($"complete:{name}");
+
+        public void Rollback(IShell shell) => events.Add($"rollback:{name}");
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the dynamic endpoint lifecycle slice tracked by elsa-workflows/elsa-foundation#1345.

- prepares and validates complete generation endpoint manifests before publication;
- rejects exact, equivalent-template, multi-method, batch, and host/shell route collisions with structured ownership diagnostics;
- commits endpoint and pipeline state through a two-phase activation participant boundary;
- binds matched requests to the exact shell generation before drain can dispose it, including cold activation rematching;
- preserves or safely recovers the previous generation when candidate activation fails;
- coordinates concurrent cleanup without exposing disposed routes or resurrecting disposed generations;
- supplies deterministic drain, rollback, race, change-token, and collectible AssemblyLoadContext evidence.

## Validation

- 631/631 CShells tests
- 31/31 end-to-end tests
- multi-target solution build: 0 warnings, 0 errors
- routing/lifecycle race group repeated 5 times
- final independent review: 0 Critical, 0 Required, 0 Advisory
- formatting and diff checks clean

## Tracking

- Elsa Foundation delivery issue: elsa-workflows/elsa-foundation#1345
- Named program: elsa-workflows/elsa-foundation#1342

The Foundation issue remains the public program record because this implementation lives in the CShells repository.